### PR TITLE
Adding tooltip for braintree transaction sale array.

### DIFF
--- a/payment-gateways/braintree/add-merchant-account-id-to-braintree-sale-array.php
+++ b/payment-gateways/braintree/add-merchant-account-id-to-braintree-sale-array.php
@@ -14,7 +14,8 @@
  */
 
 function my_pmpro_braintree_transaction_sale_array( $braintree_sale_array ) {
-    $braintree_sale_array['merchant_account_id'] => 'your_merchant_account_id';
+	$braintree_sale_array['merchant_account_id'] => 'your_merchant_account_id';
 	return $braintree_sale_array;
 }
  add_filter( 'pmpro_braintree_transaction_sale_array', 'my_pmpro_braintree_transaction_sale_array' );
+

--- a/payment-gateways/braintree/add-merchant-account-id-to-braintree-sale-array.php
+++ b/payment-gateways/braintree/add-merchant-account-id-to-braintree-sale-array.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Add a specific Merchant Account ID to the Braintree sale array when creating a transaction.
+ *
+ * title: Set the Merchant Account ID for Braintree Transactions
+ * layout: snippet
+ * collection: payment-gateways, braintree
+ * category: transaction
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+function my_pmpro_braintree_transaction_sale_array( $braintree_sale_array ) {
+    $braintree_sale_array['merchant_account_id'] => 'your_merchant_account_id';
+	return $braintree_sale_array;
+}
+ add_filter( 'pmpro_braintree_transaction_sale_array', 'my_pmpro_braintree_transaction_sale_array' );


### PR DESCRIPTION
New tooltip to demonstrate the hook: https://www.paidmembershipspro.com/hook/pmpro_braintree_transaction_sale_array/

This is based on an actual customer's need to change the merchant account ID so that they could use one with a currency unique from their default merchant account.