### PR TITLE
Adding gists for upcoming tooltips

### DIFF
--- a/admin-pages/add-quarterly-membership-level-template.php
+++ b/admin-pages/add-quarterly-membership-level-template.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Add a quarterly membership level template option when adding a new membership level in the admin.
+ *
+ * title: Add Quarterly membership level template to the Membership Levels > Add New admin popup.
+ * layout: snippet
+ * collection: admin-pages
+ * category: membership-levels
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * First, add the new template to the popup.
+ */
+function add_template_pmpro_membershiplevels_templates( $level_templates ) {
+	// Adjust and uncomment this line if you want to remove an existing 
+	$level_templates['quarterly'] = array(
+		'name' => __( 'Quarterly', 'paid-memberships-pro' ),
+		'description' => __( 'Set up a level that bills every 3 months.', 'paid-memberships-pro' ),
+	);
+	return $level_templates;
+}
+add_filter( 'pmpro_membershiplevels_templates', 'add_template_pmpro_membershiplevels_templates' );
+
+/**
+ * Then, configure level object defaults for the Quarterly template option.
+ */
+function quarterly_template_pmpro_membershiplevels_template_level( $level, $template ) {
+	// Return earliy if this isn't the quarterly template.
+	if ( $template != 'quarterly' ) {
+		return $level;
+	}
+
+	// Set the defaults for the quarterly level.
+	$level->initial_payment = 15;
+	$level->billing_amount = 15;
+	$level->cycle_number = 3;
+	$level->cycle_period = 'Month';
+	$level->billing_limit = NULL;
+	$level->trial_amount = NULL;
+	$level->trial_limit = NULL;
+	$level->expiration_number = NULL;
+	$level->expiration_period = NULL;
+
+	// Return the level object.
+	return $level;
+}
+add_filter( 'pmpro_membershiplevels_template_level', 'quarterly_template_pmpro_membershiplevels_template_level', 10, 2 );

--- a/admin-pages/remove-membership-level-templates-from-popup.php
+++ b/admin-pages/remove-membership-level-templates-from-popup.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Remove one or more built-in level templates when adding a new membership level in the admin.
+ *
+ * This recipe has two examples: removing a single template from the built-in list OR the code to unset all built-in templates.
+ *
+ * title: Remove built-in level templates from the Membership Levels > Add New admin popup.
+ * layout: snippet
+ * collection: admin-pages
+ * category: membership-levels
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * Remove the "trial" template or unset all templates from the Membership Levels > Add New popup.
+ *
+ */
+function remove_template_pmpro_membershiplevels_templates( $level_templates ) {
+	// Remove the "Trial" level template.
+	unset( $level_templates['trial'] );
+
+	// Remove all level templates.
+	//$level_templates = array();
+
+	return $level_templates;
+}
+add_filter( 'pmpro_membershiplevels_templates', 'remove_template_pmpro_membershiplevels_templates' );

--- a/admin-pages/show-next-last-payment-dates-members-list.php
+++ b/admin-pages/show-next-last-payment-dates-members-list.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Show the member's last payment date and next payment date on the Members list and Members CSV export.
+ *
+ * Note that "last payment" value will get the last order in "success", "cancelled", or "" status. (Oddly enough, cancelled here means that the membership was cancelled, not the order.)
+ *
+ * The "next payment" value is an estimate based on the billing cycle of the subscription and the last order date. It may be off from the actual recurring date set at the gateway, especially if the subscription was updated at the gateway.
+ *
+ * title: Show next and last payment date on the Members list and Members CSV export.
+ * layout: snippet
+ * collection: admin-pages
+ * category: admin
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * Adds "Last Payment" and "Next Payment" columns to Members List.
+ *
+ * @param  array $columns for table.
+ * @return array
+ */
+function my_pmpro_add_memberslist_col_payment_dates( $columns ) {
+    $columns[ 'last-payment' ] = 'Last Payment';
+    $columns[ 'next-payment' ] = 'Next Payment';
+    return $columns;
+}
+add_filter( 'pmpro_manage_memberslist_columns', 'my_pmpro_add_memberslist_col_payment_dates' );
+
+/**
+ * Fills the "last-payment" and "next-payment" columns of the Members List.
+ *
+ * @param  string $colname column being filled.
+ * @param  string $user_id to get information for.
+ */
+function my_pmpro_fill_memberslist_col_payment_dates( $colname, $user_id ) {
+    if ( 'last-payment' === $colname ) {
+        $order = new MemberOrder();
+        $order->getLastMemberOrder( $user_id, array( 'success', 'cancelled', '' ) );
+
+        if ( ! empty( $order ) && ! empty( $order->id ) ) {
+            echo date( get_option('date_format'), $order->timestamp );
+        } else {
+            echo 'N/A';
+        }
+    }
+
+    if ( 'next-payment' === $colname ) {
+        $next = pmpro_next_payment( $user_id, array( 'success', 'cancelled', '' ), 'date_format' ); 
+        if ( $next ) {
+            echo $next;
+        } else {
+            echo 'N/A';
+        }
+    }
+}
+add_filter( 'pmpro_manage_memberslist_custom_column', 'my_pmpro_fill_memberslist_col_payment_dates', 10, 2 );
+
+/**
+ * Adds "Last Payment" and "Next Payment" columns to Members List CSV export.
+ *
+ */
+function my_pmpro_members_list_csv_extra_columns_payment_dates( $columns ) {
+    $columns[ 'last_payment' ] = 'my_extra_column_last_payment';
+    $columns[ 'next_payment' ] = 'my_extra_column_next_payment';
+
+    return $columns;
+}
+add_filter( 'pmpro_members_list_csv_extra_columns', 'my_pmpro_members_list_csv_extra_columns_payment_dates', 10);
+
+/**
+ * Populate the "last_payment" column of the Members List CSV export.
+ *
+ */
+function my_extra_column_last_payment( $user ) {
+    $order = new MemberOrder();
+    $order->getLastMemberOrder( $user->ID, array( 'success', 'cancelled', '' ) );
+
+    if ( ! empty( $order ) && ! empty( $order->id ) ) {
+        return date( get_option('date_format'), $order->timestamp );
+    } else {
+        return '';
+    }
+}
+
+/**
+ * Populate the "next_payment" column of the Members List CSV export.
+ *
+ */
+function my_extra_column_next_payment( $user ) {
+    return pmpro_next_payment( $user->ID, array( 'success', 'cancelled', '' ), 'date_format' );
+}

--- a/admin-pages/show-renewal-date-orders-list.php
+++ b/admin-pages/show-renewal-date-orders-list.php
@@ -1,0 +1,43 @@
+
+<?php
+/**
+ * Show the renewal date for the order on the Memberships > Orders page in the WordPress admin.
+ *
+ * Note that the "renewal date" value is an estimate based on the billing cycle of the subscription and the last order date. It may be off from the actual recurring date set at the gateway, especially if the subscription was updated at the gateway.
+ *
+ * title: Show renewal date on the Orders list in the WordPress admin.
+ * layout: snippet
+ * collection: admin-pages
+ * category: admin
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+function my_pmpro_renewal_date_orders_extra_cols_header( $order_ids ) {
+	echo '<td>Renewal Date</td>';
+}
+add_action( 'pmpro_orders_extra_cols_header', 'my_pmpro_renewal_date_orders_extra_cols_header' );
+
+function my_pmpro_renewal_date_orders_extra_cols_body( $order ) {
+	if ( empty( $order->id ) && empty( $order->subscription_transaction_id ) ) {
+		echo '<td>&#8212;</td>';
+	} elseif ( $order->status == 'cancelled' ) {
+		echo '<td>&#8212;</td>';
+	} else {
+		// Get the membership level for the last order.
+		$level = $order->getMembershipLevel();
+
+		if ( ! empty( $level ) && ! empty( $level->id ) && ! empty( $level->cycle_number ) ) {
+			// Next Payment Date
+			$nextdate = strtotime( '+' . $level->cycle_number . ' ' . $level->cycle_period, $order->getTimestamp() );
+			echo '<td>' . date_i18n( get_option( 'date_format' ), $nextdate ) . '</td>';
+		} else {
+			// no order or level found, or level was not recurring
+			echo '<td>&#8212;</td>';
+		}
+	}
+}
+add_action( 'pmpro_orders_extra_cols_body', 'my_pmpro_renewal_date_orders_extra_cols_body' );

--- a/misc/return-active-members-with-usermeta-for-level-id.php
+++ b/misc/return-active-members-with-usermeta-for-level-id.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Function to retrieve active members of a level with required usermeta field.
+ *
+ * Example Usage:
+ * $level_one_active_users = my_pmpro_get_level_active_users( 1, ARRAY_A );
+ *
+ * title: Retrieve all active members with required usermeta field for a specific membership level ID.
+ * layout: snippet
+ * collection: misc
+ * category: members
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * Return an array of all active members with the usermeta fields first name, last name, and pet name in an associative array.
+ *
+ * @param [mixed] $level Level ID (number) as integer or string
+ * @param [constant] $output (Optional) Any of ARRAY_A | ARRAY_N | OBJECT | OBJECT_K constants. Default is OBJECT.
+ * @return [mixed] $results Format returned depends on $output parameter.
+ *
+ */
+function my_pmpro_get_level_active_users( $level, $output = OBJECT ) {
+	global $wpdb;
+
+	$results = '';
+	$results = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT u.ID, u.user_login, u.user_email, u.display_name, firstname.meta_value as first_name, lastname.meta_value as last_name, petname.meta_value as pet_name,
+			mu.membership_id, m.name as membership_name
+			FROM wp_users u
+			INNER JOIN (SELECT user_id, meta_value FROM $wpdb->usermeta WHERE meta_key = 'first_name') as firstname ON u.ID = firstname.user_id
+			INNER JOIN (SELECT user_id, meta_value FROM $wpdb->usermeta WHERE meta_key = 'last_name') as lastname ON u.ID = lastname.user_id
+			INNER JOIN (SELECT user_id, meta_value FROM $wpdb->usermeta WHERE meta_key = 'pet_name') as petname ON u.ID = petname.user_id
+			LEFT JOIN $wpdb->pmpro_memberships_users mu
+			ON u.ID = mu.user_id
+			LEFT JOIN $wpdb->pmpro_membership_levels m
+			ON mu.membership_id = m.id
+			WHERE mu.membership_id > 0  AND mu.status = 'active' AND mu.membership_id = %s  GROUP BY u.ID  ORDER BY u.ID DESC ",
+			$level
+		),
+		$output
+	);
+	return $results;
+}


### PR DESCRIPTION
Adding a few gists to be used in upcoming tooltips.

- Show next and last payment date on members list and members list CSV export.
- Show renewal date on orders list
- Remove one or unset all level templates from the Add New membership level pop up in PMPro v2.9+
- Add new level template 'quarterly' to popup and create defaults for level object
- Function to retrieve active members of a level with required usermeta field.