### PR TITLE
Add billing address fields to user profile edit pages.

### DIFF
--- a/user-fields/add-billing-address-to-user-profile-edit-page.php
+++ b/user-fields/add-billing-address-to-user-profile-edit-page.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This will add billing fields to the administrative user profile edit page for administrators
+ * and on the frontend PMPro user Edit Profile page for members.
+ *
+ * This code recipe requires Paid Memberships Pro version 2.9.0 or higher.
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function add_billing_fields_to_user_profile_edit() {
+
+	// Require PMPro and PMPro Register Helper
+	if ( ! defined( 'PMPRO_VERSION' ) || version_compare( PMPRO_VERSION, '2.9.0', '<' ) ) {
+		return;
+	}
+
+	global $pmpro_countries;
+
+	// Define the fields
+	$fields = array();
+
+	// List the fields you want to include
+	$address_fields = array(
+		'pmpro_bfirstname' => 'First Name',
+		'pmpro_blastname'  => 'Last Name',
+		'pmpro_baddress1'  => 'Address 1',
+		'pmpro_baddress2'  => 'Address 2',
+		'pmpro_bcity'      => 'City',
+		'pmpro_bstate'     => 'State',
+		'pmpro_bzipcode'   => 'Zipcode',
+		'pmpro_bcountry'   => 'Country',
+		'pmpro_bphone'     => 'Phone',
+	);
+
+	foreach ( $address_fields as $name => $label ) {
+		$options = 'pmpro_bcountry' === $name ? $pmpro_countries : array();
+		$type    = 'pmpro_bcountry' === $name ? 'select' : 'text';
+
+		$fields[] = new PMProRH_Field(
+			$name,
+			$type,
+			array(
+				'label'           => $label,
+				'size'            => 40,
+				'profile'         => 'only',
+				'options'         => $options,
+				'addmember'       => true,
+				'required'        => true, // comment this out to make the fields optional.
+				'html_attributes' => array( 'required' => 'required' ), // comment this out to make the fields optional.
+			)
+		);
+	}
+
+	// Add new checkout box with label
+	pmpro_add_field_group( 'billing_address_profile', 'Billing Address' );
+
+	// Add fields into a new checkout_boxes area of checkout page
+	foreach ( $fields as $field ) {
+		pmpro_add_user_field(
+			'billing_address_profile', // location on checkout page
+			$field            // PMPro_Field object
+		);
+	}
+}
+add_action( 'init', 'add_billing_fields_to_user_profile_edit' );

--- a/user-fields/add-billing-address-to-user-profile-edit-page.php
+++ b/user-fields/add-billing-address-to-user-profile-edit-page.php
@@ -37,18 +37,14 @@ function add_billing_fields_to_user_profile_edit() {
 	);
 
 	foreach ( $address_fields as $name => $label ) {
-		// $options = 'pmpro_bcountry' === $name ? $pmpro_countries : array();
-		// $type    = 'pmpro_bcountry' === $name ? 'select' : 'text';
-
+		// Set the field type and options based on the field name.
 		if ( $name === 'pmpro_bcountry' ) {
-			if ( ! empty( $pmpro_countries ) ) {
 				$options = $pmpro_countries;
 				$type    = 'select';
 			} else {
 				$options = array();
 				$type    = 'text';
-			}	
-		}
+			}
 
 		$fields[] = new PMProRH_Field(
 			$name,

--- a/user-fields/add-billing-address-to-user-profile-edit-page.php
+++ b/user-fields/add-billing-address-to-user-profile-edit-page.php
@@ -1,9 +1,11 @@
 <?php
 /**
- * This will add billing fields to the administrative user profile edit page for administrators
- * and on the frontend PMPro user Edit Profile page for members.
+ * Add default billing fields to the user profile edit page for admins and frontend edit profile for members.
  *
- * This code recipe requires Paid Memberships Pro version 2.9.0 or higher.
+ * title: Add billing fields to user profile edit page.
+ * layout: snippet
+ * collection: user-fields
+ * category: custom-fields
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
@@ -11,13 +13,12 @@
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
 function add_billing_fields_to_user_profile_edit() {
+	global $pmpro_countries;
 
 	// Require PMPro and PMPro Register Helper
 	if ( ! defined( 'PMPRO_VERSION' ) || version_compare( PMPRO_VERSION, '2.9.0', '<' ) ) {
 		return;
 	}
-
-	global $pmpro_countries;
 
 	// Define the fields
 	$fields = array();
@@ -36,8 +37,18 @@ function add_billing_fields_to_user_profile_edit() {
 	);
 
 	foreach ( $address_fields as $name => $label ) {
-		$options = 'pmpro_bcountry' === $name ? $pmpro_countries : array();
-		$type    = 'pmpro_bcountry' === $name ? 'select' : 'text';
+		// $options = 'pmpro_bcountry' === $name ? $pmpro_countries : array();
+		// $type    = 'pmpro_bcountry' === $name ? 'select' : 'text';
+
+		if ( $name === 'pmpro_bcountry' ) {
+			if ( ! empty( $pmpro_countries ) ) {
+				$options = $pmpro_countries;
+				$type    = 'select';
+			} else {
+				$options = array();
+				$type    = 'text';
+			}	
+		}
 
 		$fields[] = new PMProRH_Field(
 			$name,


### PR DESCRIPTION
Use the User Fields class to Display the Member’s Billing Address Fields on the Edit User Page and PMPro Member Profile Edit Page

Similar to RH method here https://www.paidmembershipspro.com/display-the-members-billing-address-fields-on-the-edit-user-page-for-admin-only/
