### PR TITLE
Recipe for a dual login / register page

### DIFF
--- a/block-templates/README.md
+++ b/block-templates/README.md
@@ -1,0 +1,3 @@
+# Snippets Library for Paid Memberships Pro - Template
+
+This README.md file has been used as a template while setting up the folder structure of this repo. 

--- a/block-templates/redirect-member-on-login.html
+++ b/block-templates/redirect-member-on-login.html
@@ -1,4 +1,4 @@
-<?php
+<!-- 
 /**
  * Show a dual login and register section on the Log In page. 
  *
@@ -8,7 +8,8 @@
  * category: login, register
  *
  * You can add this recipe directly to the Log In page > Code View in the WordPress Block Editor.
- */
+ */ 
+-->
 
 <!-- wp:columns {"verticalAlignment":"top"} -->
 <div class="wp-block-columns are-vertically-aligned-top"><!-- wp:column {"verticalAlignment":"top"} -->

--- a/misc/redirect-member-on-login.php
+++ b/misc/redirect-member-on-login.php
@@ -1,23 +1,51 @@
 <?php
 /**
- * Redirect members to a specific page when logging in.
+ * Show a dual login and register section on the Log In page. 
  *
- * title: Redirect members on login.
+ * title: Dual Log In and Register callout on Log In page.
  * layout: snippet
  * collection: misc
- * category: login redirect
+ * category: login, register
  *
- * You can add this recipe to your site by creating a custom plugin
- * or using the Code Snippets plugin available for free in the WordPress repository.
- * Read this companion article for step-by-step directions on either method.
- * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ * You can add this recipe directly to the Log In page > Code View in the WordPress Block Editor.
  */
-function my_pmpro_login_redirect_url( $redirect_to, $request, $user ) {
-	// If logged in and a member, send to members page.
-	if ( pmpro_hasMembershipLevel( null, $user->ID ) ) {
-		$redirect_to = '/members/';
-	}
 
-	return $redirect_to;
-}
-add_filter( 'pmpro_login_redirect_url', 'my_pmpro_login_redirect_url', 10, 3 );
+<!-- wp:columns {"verticalAlignment":"top"} -->
+<div class="wp-block-columns are-vertically-aligned-top"><!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:group {"backgroundColor":"site-background"} -->
+<div class="wp-block-group has-site-background-background-color has-background"><!-- wp:heading -->
+<h2 id="h-log-in">Log In</h2>
+<!-- /wp:heading -->
+
+<!-- wp:pmpro/login-form /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:group -->
+<div class="wp-block-group"><!-- wp:pmpro/membership {"levels":["0"],"uid":"0.290967777233093"} -->
+<div class="wp-block-pmpro-membership"><!-- wp:group {"style":{"color":{"background":"#f1f1f1"}}} -->
+<div class="wp-block-group has-background" style="background-color:#f1f1f1"><!-- wp:heading -->
+<h2 id="h-register-for-free">Register for Free</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Must Love Dogs is world's most barkworthy community for people that love their pooch.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Start with a <a href="/membership-account/membership-checkout/?level=5" data-type="URL" data-id="/membership-account/membership-checkout/?level=5">Free Account</a> to get started with the community.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Or, <a href="/membership-account/membership-levels/" data-type="URL" data-id="/membership-account/membership-levels/">choose a paid plan</a> to access all our best stuff.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:shortcode -->
+[memberlite_btn href="/membership-account/membership-levels/" text="Choose a Plan" style="primary"]
+<!-- /wp:shortcode --></div>
+<!-- /wp:group --></div>
+<!-- /wp:pmpro/membership --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->


### PR DESCRIPTION
This is the code to be put inside the editor (code view) for a dual login | signup page.

![pmpro-dual-login-register-page](https://user-images.githubusercontent.com/5312875/189461476-1d291fa2-7eb9-46a5-929d-d0026bd8d47b.png)
