### PR TITLE
Only discounts regular priced items, excludes any items that are on sale

### DIFF
--- a/add-ons/pmpro-woocommerce/only-discount-regular-price-items.php
+++ b/add-ons/pmpro-woocommerce/only-discount-regular-price-items.php
@@ -19,7 +19,6 @@
 
  function mypmpro_discount_sales( $discount_price, $lowest_price_level, $price, $product ) {
 
-	$regular_price = $product->get_regular_price();
 	$sale_price = $product->get_sale_price();
 
 	if( empty( $sale_price ) ) {

--- a/add-ons/pmpro-woocommerce/only-discount-regular-price-items.php
+++ b/add-ons/pmpro-woocommerce/only-discount-regular-price-items.php
@@ -21,7 +21,7 @@
 
 	$sale_price = $product->get_sale_price();
 
-	if( empty( $sale_price ) ) {
+	if (  ! $product->is_on_sale() ) {
 		//Its not on sale, so we can discount it
 		return $discount_price;
 	}

--- a/add-ons/pmpro-woocommerce/only-discount-regular-price-items.php
+++ b/add-ons/pmpro-woocommerce/only-discount-regular-price-items.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This recipe ensures that only products that are NOT on sale will be discounted
+ * when using the Woocommerce Add On. 
+ * All other products will be discounted as expected.
+ * 
+ * Learn more at https://www.paidmembershipspro.com/woocommerce-specific-category-free-for-members/
+ *
+ * title: Only discounts regular priced items, excludes any items that are on sale
+ * layout: snippet
+ * collection: add-ons
+ * category: pmpro-woocommerce
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+ function mypmpro_discount_sales( $discount_price, $lowest_price_level, $price, $product ) {
+
+	$regular_price = $product->get_regular_price();
+	$sale_price = $product->get_sale_price();
+
+	if( empty( $sale_price ) ) {
+		//Its not on sale, so we can discount it
+		return $discount_price;
+	}
+
+	//On sale, dont discount it further
+	return $sale_price;
+
+}
+add_filter( 'pmprowoo_get_membership_price', 'mypmpro_discount_sales', 10, 4 );


### PR DESCRIPTION
This recipe ensures that only products that are NOT on sale will be discounted when using the Woocommerce Add On. 

All other products will be discounted as expected.

https://gist.github.com/JarrydLong/6fcd0b9a427c96e22ae5b338f8b0b0dd