### PR TITLE
Filter to only allow access to a protected post by post ID after a specific calendar date.

### DIFF
--- a/restricting-content/unlock-post-by-ID-on-specifc-date.php
+++ b/restricting-content/unlock-post-by-ID-on-specifc-date.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Filter to only allow access to a protected post by post ID after a specific calendar date.
+ *
+ * Update the $posts_in_series_with_dates array with your post IDs => date (formatted as YYYY-MM-DD).
+ *
+ * title: Unlock post IDs on specific dates.
+ * layout: snippet
+ * collection: restricting-content
+ * category: content, restriction
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * 
+ */
+function my_pmpro_has_membership_access_on_date( $hasaccess, $post, $user ) {
+	// If they already don't have access, return.
+	if ( ! $hasaccess ) {
+		return $hasaccess;
+	}
+
+	// Set the post IDs and dates in an array.
+	$posts_in_series_with_dates = array(
+		'123' => '2023-10-28',
+		'456' => '2023-10-29',
+		'789' => '2023-10-30'
+	);
+
+	// Check if the post is in the array.
+	if ( array_key_exists( $post->ID, $posts_in_series_with_dates ) ) {
+		// Check if the current time of the WordPress site server is less than the date in the array.
+		if ( current_time( 'timestamp' ) < strtotime( $posts_in_series_with_dates[$post->ID], current_time( 'timestamp' ) ) ) {
+			$hasaccess = false;
+		}
+	}
+
+	return $hasaccess;
+}
+add_filter( 'pmpro_has_membership_access_filter', 'my_pmpro_has_membership_access_on_date', 10, 3 );

--- a/restricting-content/unlock-post-by-ID-on-specifc-date.php
+++ b/restricting-content/unlock-post-by-ID-on-specifc-date.php
@@ -14,10 +14,6 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-
-/**
- * 
- */
 function my_pmpro_has_membership_access_on_date( $hasaccess, $post, $user ) {
 	// If they already don't have access, return.
 	if ( ! $hasaccess ) {


### PR DESCRIPTION
Recipe with array of post IDs to dates (YYYY-MM-DD) as a workaround to date-specific series content access.

Set post membership levels requirements using standard PMPro 'require membership' checkboxes, then use this code to add an additional date-specific content filter.

the no access message might also need filtering or be misleading, but this is the first step to take.