### PR TITLE
Pre-check if PMPro is active and user has a level.

### DIFF
--- a/add-ons/pmpro-woocommerce/strike-through-pricing-woocommerce.php
+++ b/add-ons/pmpro-woocommerce/strike-through-pricing-woocommerce.php
@@ -16,17 +16,13 @@
 function my_pmprowoo_strike_prices( $price, $product ) {
 	global $pmprowoo_member_discounts, $current_user;
 
-	// Let's not adjust things while in the admin area.
-	if ( is_admin() ) {
+	// Let's not do this in the admin area, if PMPro is not active, or if the user does not have a membership level.
+	if ( is_admin() || ! function_exists( 'pmpro_hasMembershipLevel' ) || ! pmpro_hasMembershipLevel() ) {
 		return $price;
 	}
 
 	$formatted_price = ''; // Define the new variable.
 	$level_id = $current_user->membership_level->id;
-
-	if ( empty( $level_id ) ) {
-		return $price;
-	}
 
 	// get pricing for simple product
 	if ( $product->is_type( 'simple' ) ) {


### PR DESCRIPTION
Bug Fix/Enhancement: Check if PMPro is active and if the user has a membership beforehand.

_PHP Warning: Attempt to read property “id” on bool_ returned when using `$level_id = $current_user->membership_level->id;`  here https://github.com/strangerstudios/pmpro-snippets-library/blob/b361e516764053723fbf50c486125ad0d259aebf/add-ons/pmpro-woocommerce/strike-through-pricing-woocommerce.php#L25C2-L25C50

Adding pre-checks before retrieving the membership level details from the user object to fix this.