### PR TITLE
Allow Author to see  their own post regardless of access.

### DIFF
--- a/misc/pmpro_has_membership_access_filter_for_authors.php
+++ b/misc/pmpro_has_membership_access_filter_for_authors.php
@@ -1,5 +1,5 @@
 <?php
-/** 
+/**
  * Make sure authors can always see their own posts.
  *
  * title: Author can see their own post even if not member.
@@ -13,11 +13,11 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-
- function pmpro_has_membership_access_filter_for_authors($hasaccess, $mypost, $myuser, $post_membership_levels) {
-	if($mypost->post_author == $myuser->ID)
+function my_pmpro_has_membership_access_filter_for_authors( $hasaccess, $mypost, $myuser, $post_membership_levels ) {
+	if ( $mypost->post_author == $myuser->ID ) {
 		$hasaccess = true;
-	
+	}
+
 	return $hasaccess;
 }
-add_filter('pmpro_has_membership_access_filter', 'pmpro_has_membership_access_filter_for_authors', 30, 4);
+add_filter( 'pmpro_has_membership_access_filter', 'my_pmpro_has_membership_access_filter_for_authors', 30, 4 );

--- a/misc/pmpro_has_membership_access_filter_for_authors.php
+++ b/misc/pmpro_has_membership_access_filter_for_authors.php
@@ -1,0 +1,23 @@
+<?php
+/** 
+ * Make sure authors can always see their own posts.
+ *
+ * title: Author can see their own post even if not member.
+ * layout: snippet
+ * collection: misc
+ * category: access
+ * url: https://www.paidmembershipspro.com/allow-authors-to-view-their-posts-regardless-of-membership-level/
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+ function pmpro_has_membership_access_filter_for_authors($hasaccess, $mypost, $myuser, $post_membership_levels) {
+	if($mypost->post_author == $myuser->ID)
+		$hasaccess = true;
+	
+	return $hasaccess;
+}
+add_filter('pmpro_has_membership_access_filter', 'pmpro_has_membership_access_filter_for_authors', 30, 4);


### PR DESCRIPTION
Make sure authors can always see their own posts.
https://www.paidmembershipspro.com/allow-authors-to-view-their-posts-regardless-of-membership-level/