### PR TITLE
Change Frontend Text for Add On Packages

### DIFF
--- a/add-ons/pmpro-addon-packages/change-frontend-text-addon-package-purchase.php
+++ b/add-ons/pmpro-addon-packages/change-frontend-text-addon-package-purchase.php
@@ -6,7 +6,7 @@
  * layout: snippet
  * collection: addons
  * category: pmpro-addon-packages
- * url: 
+ * url: https://www.paidmembershipspro.com/change-frontend-text-addon-package-purchase-using-wp-gettext-filter/
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
@@ -16,22 +16,21 @@
 
  // Update Your custom text your preferred messages., romove elseif 
  // condition if you don't want to change that text.
- function my_gettext_pmproap_changes($translated_text, $text, $domain)
- {
-     if ($domain == "pmpro-addon-packages" && $text == "Purchase this Content (%s)") {
-         $translated_text = "Your custom text. %s";
-     } elseif ($domain == "pmpro-addon-packages" && $text == "Click here to checkout") {
-         $translated_text = "Your custom text. ";
-     }  elseif ($domain == "pmpro-addon-packages" && $text == "Click here to choose a membership level.") {
-         $translated_text = "Your custom text.";
-     } elseif ($domain == "pmpro-addon-packages" && $text == "Choose a Membership Level") {
-         $translated_text = "Your custom text.";
-     } elseif ($domain == "pmpro-addon-packages" && $text == "Choose a Level") {
-         $translated_text = "Your custom text.";
-     } elseif ($domain == "pmpro-addon-packages" && $text == "Buy Now") {
-         $translated_text = "Your custom text.";
-     }
- 
-     return $translated_text;
-    }
-    add_filter('gettext', 'my_gettext_pmproap_changes', 10, 3);
+function my_gettext_pmproap_changes( $translated_text, $text, $domain ) {
+	if ( $domain == 'pmpro-addon-packages' && $text == 'Purchase this Content (%s)' ) {
+		$translated_text = 'Your custom text. %s';
+	} elseif ( $domain == 'pmpro-addon-packages' && $text == 'Click here to checkout' ) {
+		$translated_text = 'Your custom text. ';
+	} elseif ( $domain == 'pmpro-addon-packages' && $text == 'Click here to choose a membership level.' ) {
+		$translated_text = 'Your custom text.';
+	} elseif ( $domain == 'pmpro-addon-packages' && $text == 'Choose a Membership Level' ) {
+		$translated_text = 'Your custom text.';
+	} elseif ( $domain == 'pmpro-addon-packages' && $text == 'Choose a Level' ) {
+		$translated_text = 'Your custom text.';
+	} elseif ( $domain == 'pmpro-addon-packages' && $text == 'Buy Now' ) {
+		$translated_text = 'Your custom text.';
+	}
+
+	return $translated_text;
+}
+add_filter( 'gettext', 'my_gettext_pmproap_changes', 10, 3 );

--- a/add-ons/pmpro-addon-packages/change-frontend-text-addon-package-purchase.php
+++ b/add-ons/pmpro-addon-packages/change-frontend-text-addon-package-purchase.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Change Front End Text for Addon Packages.
+ *
+ * title: Change Frontend Text for Add On Packages
+ * layout: snippet
+ * collection: addons
+ * category: pmpro-addon-packages
+ * url: 
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+ // Update Your custom text your preferred messages., romove elseif 
+ // condition if you don't want to change that text.
+ function my_gettext_pmproap_changes($translated_text, $text, $domain)
+ {
+     if ($domain == "pmpro-addon-packages" && $text == "Purchase this Content (%s)") {
+         $translated_text = "Your custom text. %s";
+     } elseif ($domain == "pmpro-addon-packages" && $text == "Click here to checkout") {
+         $translated_text = "Your custom text. ";
+     }  elseif ($domain == "pmpro-addon-packages" && $text == "Click here to choose a membership level.") {
+         $translated_text = "Your custom text.";
+     } elseif ($domain == "pmpro-addon-packages" && $text == "Choose a Membership Level") {
+         $translated_text = "Your custom text.";
+     } elseif ($domain == "pmpro-addon-packages" && $text == "Choose a Level") {
+         $translated_text = "Your custom text.";
+     } elseif ($domain == "pmpro-addon-packages" && $text == "Buy Now") {
+         $translated_text = "Your custom text.";
+     }
+ 
+     return $translated_text;
+    }
+    add_filter('gettext', 'my_gettext_pmproap_changes', 10, 3);


### PR DESCRIPTION
I've updated the original snippet to include all changeable text.

The post will need to be updated, too (instructions refer to specific Lines.) 

https://www.paidmembershipspro.com/change-frontend-text-addon-package-purchase-using-wp-gettext-filter/