### PR TITLE
Remove gift-only levels from table

### DIFF
--- a/add-ons/pmpro-gift-levels/remove-gift-only-levels-from-table.php
+++ b/add-ons/pmpro-gift-levels/remove-gift-only-levels-from-table.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This recipe removes levels you can get with a gift code only from the levels table
+ *
+ * title: Remove gift-only levels from table
+ * layout: snippet
+ * collection: add-ons
+ * category: pmpro-gift-levels
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * Remove gift-only levels from table
+ */
+function my_pmpro_remove_gift_only_levels_from_table( $levels ) {
+	global $pmprogl_require_gift_code;
+
+	if ( is_array( $pmprogl_require_gift_code ) ) {
+		foreach ( $pmprogl_require_gift_code as $gift_level_id ) {
+			unset( $levels[ $gift_level_id ] );
+		}
+	}
+
+	return $levels;
+}
+
+add_filter( 'pmpro_levels_array', 'my_pmpro_remove_gift_only_levels_from_table' );


### PR DESCRIPTION
This recipe removes levels you can get with a gift code only from the levels table

Let's assume you used the UI to create a certain gift level, activating a specific level (gift-receiver level) which is accessible via gift only. To achieve this, you have to manually set `$pmprogl_require_gift_code` array via code.

Also, you probably want that dedicated gift-receiver level to not be shown on levels page.