### PR TITLE
Removes the old CONPD global

### DIFF
--- a/membership-levels/change-membership-level-on-cancellation-expiration.php
+++ b/membership-levels/change-membership-level-on-cancellation-expiration.php
@@ -18,13 +18,6 @@
 
 function pmpro_after_change_membership_level_default_level( $level_id, $user_id ) {
 
-	// if we see this global set, then another gist is planning to give the user their level back
-	global $pmpro_next_payment_timestamp;
-
-	if ( ! empty( $pmpro_next_payment_timestamp ) ) {
-		return;
-	}
-
 	if ( $level_id == 0 ) {
 		// cancelling, give them level 1 instead
 		pmpro_changeMembershipLevel( 1, $user_id );


### PR DESCRIPTION
Assigns a membership level when cancelling or expiring.

Removes the old CONPD global as this is no longer used