### PR TITLE
Add email confirmation status column

### DIFF
--- a/add-ons/pmpro-approvals/add-email-confirmation-column.php
+++ b/add-ons/pmpro-approvals/add-email-confirmation-column.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This recipe adds an "Email Confirmation" column to the Approvals admin screen when using PMPro Approvals.
+ *
+ * The recipe assumes the Email Confirmation Add On is active.
+ *
+ * title: Add Email Confirmation status to Approvals admin screen.
+ * layout: snippet
+ * collection: add-ons
+ * category: pmpro-approvals
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+ // Add column header
+function my_pmpro_approvals_list_extra_cols_header_email_confirmation( $theusers ) {
+	?>
+	<th><?php esc_html_e( 'Email Confirmation', 'pmpro-email-confirmation' ); ?></th>
+	<?php
+}
+add_action( 'pmpro_approvals_list_extra_cols_header', 'my_pmpro_approvals_list_extra_cols_header_email_confirmation' );
+
+//Add 'Email Confirmation' status to Approved List Rows
+function my_pmpro_approvals_list_extra_cols_body_email_confirmation( $theuser ) {
+	?>
+	<td>
+		<?php
+		// Show pending if the email confirmation key is set in user meta, otherwise show confirmed.
+		if ( ! empty( $theuser->pmpro_email_confirmation_key ) ) {
+			esc_html_e( 'Pending' );
+		} else {
+			esc_html_e( 'Confirmed' );
+		}
+		?>
+	</td>
+	<?php
+}
+add_action( 'pmpro_approvals_list_extra_cols_body', 'my_pmpro_approvals_list_extra_cols_body_email_confirmation' );

--- a/add-ons/pmpro-approvals/add-email-confirmation-column.php
+++ b/add-ons/pmpro-approvals/add-email-confirmation-column.php
@@ -15,26 +15,28 @@
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
 
- // Add column header
-function my_pmpro_approvals_list_extra_cols_header_email_confirmation( $theusers ) {
+// Add column header
+function my_pmpro_approvals_list_extra_cols_header_email_confirmation( $the_user ) {
 	?>
 	<th><?php esc_html_e( 'Email Confirmation', 'pmpro-email-confirmation' ); ?></th>
 	<?php
 }
 add_action( 'pmpro_approvals_list_extra_cols_header', 'my_pmpro_approvals_list_extra_cols_header_email_confirmation' );
 
-//Add 'Email Confirmation' status to Approved List Rows
-function my_pmpro_approvals_list_extra_cols_body_email_confirmation( $theuser ) {
+// Add column body
+function my_pmpro_approvals_list_extra_cols_body_email_confirmation( $the_user ) {
 	?>
 	<td>
-		<?php
-		// Show pending if the email confirmation key is set in user meta, otherwise show confirmed.
-		if ( ! empty( $theuser->pmpro_email_confirmation_key ) ) {
-			esc_html_e( 'Pending' );
-		} else {
-			esc_html_e( 'Confirmed' );
-		}
-		?>
+	<?php
+	$email_confirmation_key = get_user_meta( $the_user->ID, 'pmpro_email_confirmation_key', true );
+	if ( empty( $email_confirmation_key ) ) {
+		esc_html_e( 'Not requested' );
+	} elseif ( 'validated' == $email_confirmation_key ) {
+		esc_html_e( 'Validated' );
+	} else {
+		esc_html_e( 'Not validated' );
+	}
+	?>
 	</td>
 	<?php
 }

--- a/add-ons/pmpro-approvals/add-email-confirmation-column.php
+++ b/add-ons/pmpro-approvals/add-email-confirmation-column.php
@@ -7,7 +7,7 @@
  * title: Add Email Confirmation status to Approvals admin screen.
  * layout: snippet
  * collection: add-ons
- * category: pmpro-approvals
+ * category: pmpro-approvals, pmpro-email-confirmation
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.


### PR DESCRIPTION
Adds an email confirmation status column to the approvals table that shows if email confirmation was not required and if it was, shows whether the email was validated or not validated.