### PR TITLE
example of Multiple emails

### DIFF
--- a/email/bcc-email-addresses-on-notifications.php
+++ b/email/bcc-email-addresses-on-notifications.php
@@ -9,6 +9,7 @@
  * layout: snippet
  * collection: email
  * category: bcc
+ * link: https://www.paidmembershipspro.com/bcc-additional-email-addresses-on-member-or-admin-notifications/
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
@@ -21,6 +22,7 @@ function my_pmpro_email_headers_admin_emails( $headers, $email ) {
 	// BCC emails already going to admin_email.
 	if ( strpos( $email->template, '_admin' ) !== false ) {
 		$headers[] = 'Bcc:' . 'otheremail@domain.com';
+		// $headers[] = 'Bcc:' . 'otheremail@domain.com,two@domain.com,three@domain.com'; //Example with multiple BCC emails
 	}
 
 	return $headers;


### PR DESCRIPTION
I added an example of adding more than one email address.

It's common in support for the users who do not code to ask for the correct syntax for adding multiple emails.

Also added the link address.
https://www.paidmembershipspro.com/bcc-additional-email-addresses-on-member-or-admin-notifications/