### PR TITLE
Adding new recipe to show a link to PayPal

### DIFF
--- a/frontend-pages/add-manage-paypal-subscription-membership-account-action-link.php
+++ b/frontend-pages/add-manage-paypal-subscription-membership-account-action-link.php
@@ -24,7 +24,7 @@ function my_pmpro_member_action_links_add_paypal( $pmpro_member_action_links, $l
 		$subscription = $subscriptions[0];
 
 		// Check if the subscription is managed by PayPal.
-		if ( $subscription->get_gateway() === 'paypal' ) {
+		if ( $subscription->get_gateway() === 'paypal_express' ) {
 			$pmpro_member_action_links['paypal'] = sprintf(
 				'<a id="pmpro_actionlink-paypal" href="%s" target="_blank">%s</a>',
 				esc_url( 'https://www.paypal.com/myaccount/autopay/' ),

--- a/frontend-pages/add-manage-paypal-subscription-membership-account-action-link.php
+++ b/frontend-pages/add-manage-paypal-subscription-membership-account-action-link.php
@@ -2,7 +2,7 @@
 /**
  * Add a "Manage Subscription at PayPal" link to the Membership Account > Memberships section for PayPal subscriptions.
  *
- * title: Add a "Manage Subscription at PayPal" to Member Action Links
+ * title: Add "Manage Subscription at PayPal" to Member Action Links
  * layout: snippet
  * collection: frontend-pages
  * category: members-links

--- a/frontend-pages/add-manage-paypal-subscription-membership-account-action-link.php
+++ b/frontend-pages/add-manage-paypal-subscription-membership-account-action-link.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Add a "Manage Subscription at PayPal" link to the Membership Account > Memberships section for PayPal subscriptions.
+ *
+ * title: Add a "Manage Subscription at PayPal" to Member Action Links
+ * layout: snippet
+ * collection: frontend-pages
+ * category: members-links
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+function my_pmpro_member_action_links_add_paypal( $pmpro_member_action_links, $level_id ) {
+	global $current_user;
+
+	// Retrieve subscriptions for the current user and level.
+	$subscriptions = PMPro_Subscription::get_subscriptions_for_user( $current_user->ID, $level_id );
+
+	// Check if there are any subscriptions and use the first one.
+	if ( ! empty( $subscriptions ) ) {
+		$subscription = $subscriptions[0];
+
+		// Check if the subscription is managed by PayPal.
+		if ( $subscription->get_gateway() === 'paypal' ) {
+			$pmpro_member_action_links['paypal'] = sprintf(
+				'<a id="pmpro_actionlink-paypal" href="%s" target="_blank">%s</a>',
+				esc_url( 'https://www.paypal.com/myaccount/autopay/' ),
+				esc_html__( 'Manage Subscription at PayPal', 'my-text-domain' )
+			);
+		}
+	}
+
+	return $pmpro_member_action_links;
+}
+add_filter( 'pmpro_member_action_links', 'my_pmpro_member_action_links_add_paypal', 10, 2 );


### PR DESCRIPTION
Is the sub is managed at PayPal, add a member action link to the card within the Memberships section of the Membership Account shortcode or block.

![Screenshot 2025-01-10 at 12 46 22 PM](https://github.com/user-attachments/assets/2145a4a0-3170-4568-a2ff-011fbb40d46f)
