### PR TITLE
Kimwhite Update the Level Cost Text Based on Country and State

### DIFF
--- a/checkout/update-level-cost-with-tax.php
+++ b/checkout/update-level-cost-with-tax.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Custom tax structure where all levels except level 1 have 7.25% tax if billing state is CA.
+ *
+ * title: Custom tax structure where all levels except level 1 have 7.25% tax if billing state is CA.
+ * layout: snippet
+ * collection: checkout
+ * category: tax
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+
+/*
+    Custom Tax Example.
+    - Requires PMPro 1.3.13 or higher.
+    - Leave the tax fields blank in the payment settings.
+    - Level 1 has no tax.
+    - Other levels have 7.25% tax for CA customers only.
+    - We update the price description to include the tax amount.
+*/
+
+//Adjust the tax
+function my_pmpro_tax( $tax, $values, $order ) {
+
+    //only applicable for levels > 1 - remove if this should apply to all levels
+    if( $order->membership_id > 1 ) {
+        if( trim( strtoupper( $order->billing->state ) ) == "CA" ) {
+            $tax = round( (float)$values['price'] * 0.075, 2 );       
+        }
+    }
+
+    return $tax;
+}
+add_filter( "pmpro_tax", "my_pmpro_tax", 10, 3 );
+
+//Adjut the level cost text
+function my_pmpro_level_cost_text( $cost, $level ) {
+
+    //only applicable for levels > 1 - remove if this should apply to all levels
+    if( $level->id > 1 ) {
+        $cost .= " Customers in CA will be charged 7.25% tax.";
+    }
+
+    return $cost;
+}
+add_filter( "pmpro_level_cost_text", "my_pmpro_level_cost_text", 10, 2 );


### PR DESCRIPTION
 *  Add WPCS to the snippet
 * get the level calling pmpro_getLevelAtCheckout() instead of taking from the request
 * add a further scenario to get back to original billing text if the tax state was selected and the another not taxed state is selected after all.
![image](https://github.com/user-attachments/assets/1f84e54a-070d-4ac5-bd03-e2736cbc5d11)
![image](https://github.com/user-attachments/assets/92f9b961-401d-4202-8fff-e10471675928)
![image](https://github.com/user-attachments/assets/d1711d59-4ec5-48d9-9d65-53af4058288d)

