### PR TITLE
Requires Membership Column

### DIFF
--- a/admin-pages/requires-membership-column-categories.php
+++ b/admin-pages/requires-membership-column-categories.php
@@ -26,12 +26,12 @@ function requires_membership_categories_columns_content( $content, $column_name,
 	if ( $column_name == 'requires_membership' ) {
 	    global $membership_levels, $wpdb;
 		$protected_levels = array();
-		foreach( $membership_levels as $level ) {
+		foreach ( $membership_levels as $level ) {
 				$protectedcategories = $wpdb->get_col(
 					"SELECT category_id 
 					 FROM $wpdb->pmpro_memberships_categories
 					 WHERE membership_id = $level->id" );
-				if( in_array( $term_id, $protectedcategories ) ) {
+				if ( in_array( $term_id, $protectedcategories ) ) {
 					$protected_levels[] = $level->name;
 				}
 		}

--- a/admin-pages/requires-membership-column-categories.php
+++ b/admin-pages/requires-membership-column-categories.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Show a “Requires Membership” Column on the All Categories Screen
+ *
+ * title: Show a “Requires Membership” Column on the All Categories Screen
+ * layout: snippet
+ * collection: admin-pages
+ * category: admin, categories
+ * url: https://www.paidmembershipspro.com/show-post-page-categorys-required-membership-levels-dashboard-views/
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+//add a new column to the categories view
+function requires_membership_categories_columns_head( $defaults ) {
+    $defaults['requires_membership'] = 'Requires Membership';
+    return $defaults;
+}
+add_filter( 'manage_edit-category_columns', 'requires_membership_categories_columns_head' );
+
+//get the column data
+function requires_membership_categories_columns_content( $content, $column_name, $term_id ) {
+	if ( $column_name == 'requires_membership' ) {
+	    global $membership_levels, $wpdb;
+		$protected_levels = array();
+		foreach( $membership_levels as $level ) {
+				$protectedcategories = $wpdb->get_col(
+					"SELECT category_id 
+					 FROM $wpdb->pmpro_memberships_categories
+					 WHERE membership_id = $level->id" );
+				if( in_array( $term_id, $protectedcategories ) ) {
+					$protected_levels[] = $level->name;
+				}
+		}
+		echo implode( ', ', $protected_levels );
+	}
+}
+add_action( 'manage_category_custom_column', 'requires_membership_categories_columns_content', 10, 3 );

--- a/admin-pages/requires-membership-column-pages.php
+++ b/admin-pages/requires-membership-column-pages.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Show a “Requires Membership” Column on the All Pages Screen
+ *
+ * title: Show a “Requires Membership” Column on the All Pages Screen
+ * layout: snippet
+ * collection: admin-pages
+ * category: admin, pages
+ * url: https://www.paidmembershipspro.com/show-post-page-categorys-required-membership-levels-dashboard-views/
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+//add a new column to the all pages view
+function requires_membership_pages_columns_head( $defaults ) {
+    $defaults['requires_membership'] = 'Requires Membership';
+    return $defaults;
+}
+add_filter( 'manage_pages_columns', 'requires_membership_pages_columns_head' );
+
+//get the column data
+function requires_membership_pages_columns_content( $column_name, $post_ID ) {
+	if ( $column_name == 'requires_membership' ) {
+	    global $membership_levels, $wpdb;
+		$post_levels = $wpdb->get_col(
+			"SELECT membership_id 
+			 FROM {$wpdb->pmpro_memberships_pages} 
+			 WHERE page_id = '{$post_ID}'" );
+		$protected_levels = array();
+		foreach( $membership_levels as $level ) {
+			if( in_array( $level->id, $post_levels ) ) {
+				$protected_levels[] = $level->name;
+			}
+		}
+		echo implode( ', ', $protected_levels);
+	}
+}
+add_action( 'manage_pages_custom_column', 'requires_membership_pages_columns_content', 10, 2 );

--- a/admin-pages/requires-membership-column-pages.php
+++ b/admin-pages/requires-membership-column-pages.php
@@ -30,8 +30,8 @@ function requires_membership_pages_columns_content( $column_name, $post_ID ) {
 			 FROM {$wpdb->pmpro_memberships_pages} 
 			 WHERE page_id = '{$post_ID}'" );
 		$protected_levels = array();
-		foreach( $membership_levels as $level ) {
-			if( in_array( $level->id, $post_levels ) ) {
+		foreach ( $membership_levels as $level ) {
+			if ( in_array( $level->id, $post_levels ) ) {
 				$protected_levels[] = $level->name;
 			}
 		}

--- a/admin-pages/requires-membership-column-posts.php
+++ b/admin-pages/requires-membership-column-posts.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Show a “Requires Membership” Column on the All Post Screen
+ *
+ * title: Show a “Requires Membership” Column on the All Post Screen
+ * layout: snippet
+ * collection: admin-pages
+ * category: admin, post
+ * url:https://www.paidmembershipspro.com/show-post-page-categorys-required-membership-levels-dashboard-views/
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+//add a new column to the all posts view
+function requires_membership_posts_columns_head( $defaults ) {
+	$defaults['requires_membership'] = 'Requires Membership';
+	return $defaults;
+}
+add_filter( 'manage_posts_columns', 'requires_membership_posts_columns_head' );
+
+//get the column data
+function requires_membership_posts_columns_content( $column_name, $post_ID ) {
+	if ( $column_name == 'requires_membership' ) {
+	    global $membership_levels, $wpdb;
+		$post_levels = $wpdb->get_col(
+			"SELECT membership_id
+			 FROM {$wpdb->pmpro_memberships_pages}
+			 WHERE page_id = '{$post_ID}'" );
+		$protected_levels = array();
+		foreach( $membership_levels as $level ) {
+			$protectedcategories = $wpdb->get_col(
+				"SELECT category_id 
+				 FROM $wpdb->pmpro_memberships_categories 
+				 WHERE membership_id = $level->id" );
+			if( in_array( $level->id, $post_levels ) || in_category( $protectedcategories, $post_ID ) ) {
+				$protected_levels[] = $level->name;
+			}
+		}
+		echo implode( ', ', $protected_levels );
+	}
+}
+add_action( 'manage_posts_custom_column', 'requires_membership_posts_columns_content', 10, 2 );

--- a/admin-pages/requires-membership-column-posts.php
+++ b/admin-pages/requires-membership-column-posts.php
@@ -30,12 +30,12 @@ function requires_membership_posts_columns_content( $column_name, $post_ID ) {
 			 FROM {$wpdb->pmpro_memberships_pages}
 			 WHERE page_id = '{$post_ID}'" );
 		$protected_levels = array();
-		foreach( $membership_levels as $level ) {
+		foreach ( $membership_levels as $level ) {
 			$protectedcategories = $wpdb->get_col(
 				"SELECT category_id 
 				 FROM $wpdb->pmpro_memberships_categories 
 				 WHERE membership_id = $level->id" );
-			if( in_array( $level->id, $post_levels ) || in_category( $protectedcategories, $post_ID ) ) {
+			if ( in_array( $level->id, $post_levels ) || in_category( $protectedcategories, $post_ID ) ) {
 				$protected_levels[] = $level->name;
 			}
 		}


### PR DESCRIPTION
 * Add recipes to add extra colum to the pages of all categories, all pages and all posts. If any membership level is required it displays in the colum. Comma separated if more than one.
 
Tests and address WPCS @kimwhite  PR -> https://github.com/strangerstudios/pmpro-snippets-library/pull/235

<img width="1699" alt="Screenshot 2025-02-04 at 12 22 37 PM" src="https://github.com/user-attachments/assets/9a14071b-0546-46bd-98ea-dd59ff44ba4d" />
<img width="1393" alt="Screenshot 2025-02-04 at 1 20 32 PM" src="https://github.com/user-attachments/assets/385845ed-3b08-4433-b914-3872af6f44fd" />
<img width="1591" alt="Screenshot 2025-02-04 at 2 09 34 PM" src="https://github.com/user-attachments/assets/96128f5a-9693-4018-a617-d2be85ab6be1" />
