### PR TITLE
Create Add A Level-Specific Fixed Fee to Checkout When Using Stripe

### DIFF
--- a/checkout/add-level-specific-fee-to-checkout.php
+++ b/checkout/add-level-specific-fee-to-checkout.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This recipe will add a fee to the initial and recurring value for specific levels when using Stripe
+ * Specify your membership levels on line 23
+ * 
+ * title: Add A Level-Specific Fixed Fee to Checkout When Using Stripe
+ * layout: snippet
+ * collection: checkout
+ * category: stripe
+ * url: https://www.paidmembershipspro.com/adjust-membership-pricing-by-payment-gateway/
+ * 
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function my_pmpro_checkout_level( $level ) {
+	//Get the gateway
+	$gateway = pmpro_getGateway();
+	//Bail if no gateway configured
+	if( ! $gateway ) {
+		return $level;
+	}
+	//Bail if the gateway is not Stripe
+	if( $gateway !== 'stripe' ) {
+		return $level;
+	}
+	//Specify the level IDs you want to adjust within the array
+	if( in_array( $level->id, array( 1, 2, 3 ) ) ) {
+		//Updates initial payment value
+		$level->initial_payment = $level->initial_payment + 3;
+		//Updates recurring payment value
+		$level->billing_amount = $level->billing_amount + 3;
+	}
+
+	return $level;
+}
+add_filter( "pmpro_checkout_level", "my_pmpro_checkout_level" );

--- a/checkout/add-level-specific-fee-to-checkout.php
+++ b/checkout/add-level-specific-fee-to-checkout.php
@@ -7,7 +7,7 @@
  * layout: snippet
  * collection: checkout
  * category: stripe
- * url: https://www.paidmembershipspro.com/adjust-membership-pricing-by-payment-gateway/
+ * link: https://www.paidmembershipspro.com/adjust-membership-pricing-by-payment-gateway/
  * 
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
@@ -18,15 +18,15 @@ function my_pmpro_checkout_level( $level ) {
 	//Get the gateway
 	$gateway = pmpro_getGateway();
 	//Bail if no gateway configured
-	if( ! $gateway ) {
+	if ( ! $gateway ) {
 		return $level;
 	}
 	//Bail if the gateway is not Stripe
-	if( $gateway !== 'stripe' ) {
+	if ( $gateway !== 'stripe' ) {
 		return $level;
 	}
 	//Specify the level IDs you want to adjust within the array
-	if( in_array( $level->id, array( 1, 2, 3 ) ) ) {
+	if ( in_array( $level->id, array( 1, 2, 3 ) ) ) {
 		//Updates initial payment value
 		$level->initial_payment = $level->initial_payment + 3;
 		//Updates recurring payment value


### PR DESCRIPTION
 * Use pmpro_getGateway() function instead of taking it from the Request object
 * Use level passed as a param by the filter instead of taking from the Request object
 * Bail instead of nest ifs
 * minor WPCS

Tests and tweaks PR https://github.com/strangerstudios/pmpro-snippets-library/pull/230/ from @MaryOJob 

<img width="1041" alt="Screenshot 2025-02-04 at 3 07 02 PM" src="https://github.com/user-attachments/assets/aaf890cd-4344-421a-8977-6223f87fc8ad" />
<img width="1059" alt="Screenshot 2025-02-04 at 3 06 44 PM" src="https://github.com/user-attachments/assets/06a0bd91-1523-49f1-a3d0-31932763c01b" />
