### PR TITLE
Hides multiple BP profile fields from Profile View until user is approved.

### DIFF
--- a/add-ons/pmpro-buddypress/buddypress-approvals-profile-fields-view.php
+++ b/add-ons/pmpro-buddypress/buddypress-approvals-profile-fields-view.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Hides multiple buddypress profile fields when an unapproved member views someone else's profile.
+ * Allows all members to see their own profiles without restrictions.
+ * Logs debugging info so you can check if the function is running correctly.
+ * Change 41 to the names of your BuddyPress Profile fields, Change line 45 to the message
+ * When using the Approvals Add On from PMPro 
+ * 
+ * title: Hide BuddyPress Profile Fields marked "members only", on the BuddyPress Profile Tab
+ * layout: snippet-example
+ * collection: pmpro-buddypress, pmpro_approvals
+ * category: buddypress, buddyboss
+ * link: none
+ * 
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+ function my_pmpro_hide_bp_fields( $field_value ) {
+    if ( ! is_user_logged_in() || bp_displayed_user_id() == get_current_user_id() ) {
+        return $field_value; // Allow logged-out users and users viewing their own profile
+    }
+    
+    if( ! function_exists( 'pmpro_getMembershipLevelForUser' ) ) {
+     return $field_value;
+    }
+
+    if ( ! class_exists( 'PMPro_Approvals' ) || ! pmpro_hasMembershipLevel( null, get_current_user_id() ) ) {
+        return $field_value; // Exit if PMPro Approvals is not active or no membership
+    }
+
+    $level = pmpro_getMembershipLevelForUser( get_current_user_id() );
+    if ( ! $level || ! PMPro_Approvals::requiresApproval( $level->id ) ) {
+        return $field_value; // Exit if level does not require approval
+    }
+
+    $approval_status = get_user_meta( get_current_user_id(), 'pmpro_approval_' . $level->id, true )['status'] ?? '';
+
+    // Define restricted fields
+    $restricted_fields = ['Email', 'Phone Number', 'Address', 'Company'];
+
+    // Hide field if the viewer is not approved
+    if ( $approval_status !== 'approved' && in_array( bp_get_the_profile_field_name(), $restricted_fields, true ) ) {
+        return __( 'Restricted to Approved Members', 'paid-memberships-pro' );
+    }
+
+    return $field_value;
+}
+add_filter( 'bp_get_the_profile_field_value', 'my_pmpro_hide_bp_fields' );

--- a/add-ons/pmpro-buddypress/buddypress-approvals-profile-fields-view.php
+++ b/add-ons/pmpro-buddypress/buddypress-approvals-profile-fields-view.php
@@ -1,51 +1,60 @@
 <?php
 /**
- * Hides multiple buddypress profile fields when an unapproved member views someone else's profile.
+ * Hides multiple buddypress profile fields when an unapproved member views someone else's profile or is logged-out.
  * Allows all members to see their own profiles without restrictions.
- * Logs debugging info so you can check if the function is running correctly.
- * Change 41 to the names of your BuddyPress Profile fields, Change line 45 to the message
- * When using the Approvals Add On from PMPro 
+ * Adjust the $restricted_fields array to include the names of the fields you want to restrict and tweak this code recipe further for your needs.
  * 
  * title: Hide BuddyPress Profile Fields marked "members only", on the BuddyPress Profile Tab
  * layout: snippet-example
  * collection: pmpro-buddypress, pmpro_approvals
  * category: buddypress, buddyboss
- * link: none
+ * link: TBD
  * 
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-
- function my_pmpro_hide_bp_fields( $field_value ) {
-    if ( ! is_user_logged_in() || bp_displayed_user_id() == get_current_user_id() ) {
-        return $field_value; // Allow logged-out users and users viewing their own profile
+function my_pmpro_hide_bp_fields( $field_value ) {
+	global $current_user;
+	
+	// Make sure PMPro is installed and available, if not bail.
+	if ( ! function_exists( 'pmpro_getMembershipLevelForUser' ) ) {
+    	return $field_value;
     }
-    
-    if( ! function_exists( 'pmpro_getMembershipLevelForUser' ) ) {
-     return $field_value;
+	
+	// Allow users viewing their own profile regardlress of status.
+    if ( bp_displayed_user_id() == $current_user->ID ) {
+        return $field_value;
     }
+	
+	// Define restricted fields we want to lockdown.
+	$restricted_fields = array( 'Email', 'Phone Number', 'Address', 'Company' );
 
-    if ( ! class_exists( 'PMPro_Approvals' ) || ! pmpro_hasMembershipLevel( null, get_current_user_id() ) ) {
-        return $field_value; // Exit if PMPro Approvals is not active or no membership
-    }
+	// Check if the field being displayed is a restricted field.
+	if ( ! in_array( bp_get_the_profile_field_name(), $restricted_fields, true ) ) {
+		return $field_value;
+	}
 
-    $level = pmpro_getMembershipLevelForUser( get_current_user_id() );
-    if ( ! $level || ! PMPro_Approvals::requiresApproval( $level->id ) ) {
-        return $field_value; // Exit if level does not require approval
-    }
+	// If a user is logged-out we can also hide this information.
+	if ( ! is_user_logged_in() ) {
+		return 'Please login to view content.';
+	}
 
-    $approval_status = get_user_meta( get_current_user_id(), 'pmpro_approval_' . $level->id, true )['status'] ?? '';
+		// Let's not fatal error if PMPro Approvals is deactivated.
+	if ( ! class_exists( 'PMPro_Approvals' ) ) {
+		return $field_value;
+	}
 
-    // Define restricted fields
-    $restricted_fields = ['Email', 'Phone Number', 'Address', 'Company'];
+		// See if the current user is not approved, then lockdown the content.
+	$level = pmpro_getMembershipLevelForUser( $current_user->ID );
+	$approved = PMPro_Approvals::isApproved( $current_user->ID, $level->id );
 
-    // Hide field if the viewer is not approved
-    if ( $approval_status !== 'approved' && in_array( bp_get_the_profile_field_name(), $restricted_fields, true ) ) {
-        return __( 'Restricted to Approved Members', 'paid-memberships-pro' );
-    }
+	// Hide field if the viewer is not approved
+	if ( ! $approved ) {
+		return __( 'Restricted to Approved Members', 'paid-memberships-pro' );
+	}
 
-    return $field_value;
+	return $field_value;
 }
 add_filter( 'bp_get_the_profile_field_value', 'my_pmpro_hide_bp_fields' );


### PR DESCRIPTION
BuddyPress has a setting on it's Profile Fields for visibility. There is a setting for Member Only, which really means user only. 
When a site is using the Approval Add On, this snippet will continue to hide the fields until the PMPro Memberships is approved.
![Screenshot 2025-03-07 at 8 04 41 AM](https://github.com/user-attachments/assets/84a04ff2-fc26-4714-a3c7-36566de6f813)
