### PR TITLE
Updating oembed disable snippet for v2.0+, adding new snippet for make_clickable

### DIFF
--- a/add-ons/pmpro-membership-directory/pmpromd-disable-oembed.php
+++ b/add-ons/pmpro-membership-directory/pmpromd-disable-oembed.php
@@ -1,8 +1,11 @@
 <?php
 /**
- * Remove embeds on the PMPro Member Directory pages.
+ * Turn embeddable links into clickable links (do not render oEmbeds) on the Member Directory.
+ * Update line 19 with the field name you want to disable oEmbed for.
+ * Update line 20 with the link display type you want to use.
+ * Link types include "embedded" (default), "clickable_link", "clickable_label", or '' for plain text.
  *
- * title: Disable oEmbed on Member Directory
+ * title: Disable oEmbed on Member Directory and Profile Pages
  * layout: snippet
  * collection: pmpro-member-directory
  * category: directory, embeds, oembed, clickable, links
@@ -13,22 +16,10 @@
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
 
-// Remove the oembed functionality.
-add_filter( 'pmpromd_try_oembed_url', '__return_false' );
-
-// Add a clickable link to field names defined in the $clickable_fields array.
-function my_pmpromd_make_clickable( $value, $original_value, $field_name ) {
-
-	/**
-	 * Set fields that should have a clickable link here,
-	 * e.g. 'user_url', 'website_url', 'user_facebook', etc.
-	 */
-	$clickable_fields = array( 'user_url' );
-
-	if ( ! empty( $clickable_fields ) && in_array( $field_name, $clickable_fields, true ) ) {
-		$value = make_clickable( $value );
+function my_pmpro_field_value_link_display_type( $link_display_type, $value, $field ) {
+	if ( isset( $field->name ) && $field->name === 'youtube_video' ) {
+		return 'clickable_link';
 	}
-
-	return $value;
+	return $link_display_type;
 }
-add_filter( 'pmpromd_format_profile_field', 'my_pmpromd_make_clickable', 10, 3 );
+add_filter( 'pmpro_field_value_link_display_type', 'my_pmpro_field_value_link_display_type', 10, 3 );

--- a/add-ons/pmpro-membership-directory/pmpromd-make-clickable.php
+++ b/add-ons/pmpro-membership-directory/pmpromd-make-clickable.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Run certain Member Directory and Profile fields through the make_clickable function.
+ *
+ * title: Make Member Directory and Profile Fields Clickable
+ * layout: snippet
+ * collection: pmpro-member-directory
+ * category: directory, profile clickable, links
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+function my_pmpromd_make_clickable( $value, $element, $pu, $displayed_levels ) {
+	// Process a specific element and make it clickable.
+	if ( $element === 'portfolio_url' ) {
+		$value = make_clickable( $value );
+	}
+
+	// Make all values clickable.
+	//if ( ! empty( $value ) ) {
+	//	$value = make_clickable( $value );
+	//}
+
+	return $value;
+}
+add_filter( 'pmpromd_get_display_value', 'my_pmpromd_make_clickable', 20, 4 );


### PR DESCRIPTION
Member Directory v2.0+ has new methods to change how a string that looks like a URL is displayed - we now can use the `pmpro_field_value_link_display_type` filter and set this to one of: "embedded" (default), "clickable_link", "clickable_label", or '' for plain text. You don't need the make_clickable snippet for this - just modify what display type you want to use for a given field name.

This PR also separates the `make_clickable` logic in a standalone snippet. That snippet should be used to make a string that may contain a link clickable. This would be used to make the email address clickable (mailto:) or convert a link inside a longer sentence of text to a clickable URL.