### PR TITLE
Update usermeta and $_REQUEST keys to include "pmpro_" prefix

### DIFF
--- a/add-ons/pmpro-mailchimp/send-shipping-fields-mailchimp.php
+++ b/add-ons/pmpro-mailchimp/send-shipping-fields-mailchimp.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * This recipe will send shipping fields to Mailchimp.
+ * This recipe will send mailing address fields to Mailchimp.
  *
- * title: send shipping fields to Mailchimp
+ * title: Send Mailing Address fields to Mailchimp
  * layout: snippets
  * collection: pmpro-mailchimp
  * category: shipping-fields, email, mailchimp
+ * link: https://www.paidmembershipspro.com/shipping-address-details-mailchimp/
  *
- * The Shipping Address on Membership Checkout Add On is required for this recipe to work
+ * The Mailing Address (formerly Shipping Address) Add On is required for this recipe to work
  * https://www.paidmembershipspro.com/add-ons/shipping-address-membership-checkout/
- *
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
@@ -17,9 +17,8 @@
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
 
-
-// Creates Shipping fields in MailChimp
-function my_pmpro_mailchimp_merge_field_shipping( $merge_fields ) {
+// Creates Mailiing fields in MailChimp
+function my_pmpro_mailchimp_merge_field_mailing( $merge_fields ) {
 
 	$merge_fields[] = array( 'name' => 'SFIRSTNAME', 'type' => 'text' );
 	$merge_fields[] = array( 'name' => 'SLASTNAME', 'type' => 'text' );
@@ -33,21 +32,21 @@ function my_pmpro_mailchimp_merge_field_shipping( $merge_fields ) {
 
 	return $merge_fields;
 }
-add_filter( 'pmpro_mailchimp_merge_fields', 'my_pmpro_mailchimp_merge_field_shipping' );
+add_filter( 'pmpro_mailchimp_merge_fields', 'my_pmpro_mailchimp_merge_field_mailing' );
 
-// Populate the Shipping fields in MailChimp from the shipping fields.
-function my_pmpro_mailchimp_listsubscribe_field_shipping( $fields, $user ) {
+// Populate the Mailing fields in MailChimp from the mailing fields.
+function my_pmpro_mailchimp_listsubscribe_field_mailing( $fields, $user ) {
 
 	$new_fields = array(
-		'SFIRSTNAME' => ( isset( $_REQUEST['sfirstname'] ) ) ? sanitize_text_field( $_REQUEST['sfirstname'] ) : get_user_meta( $user->ID, 'sfirstname', true ),
-		'SLASTNAME'  => ( isset( $_REQUEST['slastname'] ) ) ? sanitize_text_field( $_REQUEST['slastname'] ) : get_user_meta( $user->ID, 'slastname', true ),
-		'SADDRESS1'  => ( isset( $_REQUEST['saddress1'] ) ) ? sanitize_text_field( $_REQUEST['saddress1'] ) : get_user_meta( $user->ID, 'saddress1', true ),
-		'SADDRESS2'  => ( isset( $_REQUEST['saddress2'] ) ) ? sanitize_text_field( $_REQUEST['saddress2'] ) : get_user_meta( $user->ID, 'saddress2', true ),
-		'SCITY'      => ( isset( $_REQUEST['scity'] ) ) ? sanitize_text_field( $_REQUEST['scity'] ) : get_user_meta( $user->ID, 'scity', true ),
-		'SSTATE'     => ( isset( $_REQUEST['sstate'] ) ) ? sanitize_text_field( $_REQUEST['sstate'] ) : get_user_meta( $user->ID, 'sstate', true ),
-		'SZIPCODE'   => ( isset( $_REQUEST['szipcode'] ) ) ? sanitize_text_field( $_REQUEST['szipcode'] ) : get_user_meta( $user->ID, 'szipcode', true ),
-		'SPHONE'     => ( isset( $_REQUEST['sphone'] ) ) ? sanitize_text_field( $_REQUEST['sphone'] ) : get_user_meta( $user->ID, 'sphone', true ),
-		'SCOUNTRY'   => ( isset( $_REQUEST['scountry'] ) ) ? sanitize_text_field( $_REQUEST['scountry'] ) : get_user_meta( $user->ID, 'scountry', true )
+		'SFIRSTNAME' => ( isset( $_REQUEST['pmpro_sfirstname'] ) ) ? sanitize_text_field( $_REQUEST['pmpro_sfirstname'] ) : get_user_meta( $user->ID, 'pmpro_sfirstname', true ),
+		'SLASTNAME'  => ( isset( $_REQUEST['pmpro_slastname'] ) ) ? sanitize_text_field( $_REQUEST['pmpro_slastname'] ) : get_user_meta( $user->ID, 'pmpro_slastname', true ),
+		'SADDRESS1'  => ( isset( $_REQUEST['pmpro_saddress1'] ) ) ? sanitize_text_field( $_REQUEST['pmpro_saddress1'] ) : get_user_meta( $user->ID, 'pmpro_saddress1', true ),
+		'SADDRESS2'  => ( isset( $_REQUEST['pmpro_saddress2'] ) ) ? sanitize_text_field( $_REQUEST['pmpro_saddress2'] ) : get_user_meta( $user->ID, 'pmpro_saddress2', true ),
+		'SCITY'      => ( isset( $_REQUEST['pmpro_scity'] ) ) ? sanitize_text_field( $_REQUEST['pmpro_scity'] ) : get_user_meta( $user->ID, 'pmpro_scity', true ),
+		'SSTATE'     => ( isset( $_REQUEST['pmpro_sstate'] ) ) ? sanitize_text_field( $_REQUEST['pmpro_sstate'] ) : get_user_meta( $user->ID, 'pmpro_sstate', true ),
+		'SZIPCODE'   => ( isset( $_REQUEST['pmpro_szipcode'] ) ) ? sanitize_text_field( $_REQUEST['pmpro_szipcode'] ) : get_user_meta( $user->ID, 'pmpro_szipcode', true ),
+		'SPHONE'     => ( isset( $_REQUEST['pmpro_sphone'] ) ) ? sanitize_text_field( $_REQUEST['pmpro_sphone'] ) : get_user_meta( $user->ID, 'pmpro_sphone', true ),
+		'SCOUNTRY'   => ( isset( $_REQUEST['pmpro_scountry'] ) ) ? sanitize_text_field( $_REQUEST['pmpro_scountry'] ) : get_user_meta( $user->ID, 'pmpro_scountry', true )
 	);
 
 	$fields = array_merge( $fields, $new_fields );
@@ -55,4 +54,4 @@ function my_pmpro_mailchimp_listsubscribe_field_shipping( $fields, $user ) {
 	return $fields;
 
 }
-add_action( 'pmpro_mailchimp_listsubscribe_fields', 'my_pmpro_mailchimp_listsubscribe_field_shipping', 10, 2 );
+add_action( 'pmpro_mailchimp_listsubscribe_fields', 'my_pmpro_mailchimp_listsubscribe_field_mailing', 10, 2 );


### PR DESCRIPTION
Snippet wasn't working with recent Mailing Address Add On releases due to change in field names. Updates keys to match those included in the Mailing Address Add On

Replaces some references of _shipping_ with _mailing_.

Adds article link to plugin header: https://www.paidmembershipspro.com/shipping-address-details-mailchimp/