### PR TITLE
Add approve membership added by admin.

### DIFF
--- a/add-ons/pmpro-approvals/approve-user-added-by-admin.php
+++ b/add-ons/pmpro-approvals/approve-user-added-by-admin.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Automatically approve users added by admin.
+ *
+ * title: Automatically approve users added by admin
+ * layout: snippet
+ * collection: add-ons
+ * category: pmpro-approvals
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function my_pmpro_automatically_approve_admin_added_user( $level_id, $user_id, $cancelled_level ) {
+
+    // Bail if not an admin or if Approvals Add On is not active or level doesn't require approval.
+	if ( ! ( current_user_can( 'manage_options' ) || ! class_exists( 'PMPro_Approvals' ) || ! PMPro_Approvals::requiresApproval( $level_id ) ) ) {
+		return;
+	}
+
+	// Let's approve the user.
+	PMPro_Approvals::approveMember( $user_id, $level_id );
+
+}
+add_action( 'pmpro_after_change_membership_level', 'my_pmpro_automatically_approve_admin_added_user', 10, 3 );

--- a/add-ons/pmpro-approvals/approve-user-added-by-admin.php
+++ b/add-ons/pmpro-approvals/approve-user-added-by-admin.php
@@ -6,6 +6,7 @@
  * layout: snippet
  * collection: add-ons
  * category: pmpro-approvals
+ * link: TBD
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.


### PR DESCRIPTION
Automatically approve a user's membership level if the user's level was added by an administrator.