### PR TITLE
Add Post link

### DIFF
--- a/add-ons/pmpro-group-accounts/my_pmprogroupacct_enforce_same_email_domain.php
+++ b/add-ons/pmpro-group-accounts/my_pmprogroupacct_enforce_same_email_domain.php
@@ -6,6 +6,7 @@
  * layout: snippet
  * collection: add-ons, pmpro-group-accounts
  * category: members, groups, email
+ * link: https://www.paidmembershipspro.com/restrict-group-child-checkout-to-email-domain-of-group-leader/
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.


### PR DESCRIPTION
Link added to snippet. https://www.paidmembershipspro.com/restrict-group-child-checkout-to-email-domain-of-group-leader/