### PR TITLE
Update Pause Member Access with New Filter

### DIFF
--- a/restricting-content/pause-member-access.php
+++ b/restricting-content/pause-member-access.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Mark a member "paused" and deny access to members-only content.
  * Show a message that their account is paused containing a link to your website contact page.
@@ -16,7 +15,6 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-
 function my_pmprouf_init_pause_access_new() {
 	if ( ! function_exists( 'pmpro_add_user_field' ) ) {
 		return false;
@@ -26,52 +24,34 @@ function my_pmprouf_init_pause_access_new() {
 	if ( ! is_admin() ) {
 		return;
 	}
-    
-    pmpro_add_field_group( 'Access to Member Content' );
 
-	// Define the field.  
-    $fields = array();
-    $fields[] = new PMPro_Field(
-        'pmpro_paused_user',
-        'checkbox',
-        array(
-            'label'   => 'Pause User',
-            'text'    => 'Deny Access to Member Content',
-            'profile' => 'admins',
-        )
-    );
+	pmpro_add_field_group( 'Access to Member Content' );
 
-    foreach ( $fields as $field ) {
-        pmpro_add_user_field(
-            'Access to Member Content',
-            $field
-        );
-    }
+	// Define the field.
+	$field = new PMPro_Field(
+		'pmpro_paused_user',
+		'checkbox',
+		array(
+			'label'   => 'Pause User',
+			'text'    => 'Deny Access to Member Content',
+			'profile' => 'admins',
+		)
+	);
+
+	pmpro_add_user_field( 'Access to Member Content', $field );
 }
-add_action( 'init', 'my_pmprouf_init_pause_access_new', 10, 1 );
+add_action( 'init', 'my_pmprouf_init_pause_access_new', 10 );
 
 /**
  * Deny access to member content if user is 'paused'.
  */
-
 function paused_member_pmpro_has_membership_access_filter( $access, $post, $user, $levels ) {
-
-	//if we don't have access now, we still won't
-	if ( ! $access ) {
+	// If no access already, or no user/levels, leave access unchanged.
+	if ( ! $access || empty( $user ) || empty( $user->ID ) || empty( $levels ) ) {
 		return $access;
 	}
 
-	//no user, this must be open to everyone
-	if ( empty( $user ) || empty( $user->ID ) ) {
-		return $access;
-	}
-
-	//no levels, must be open
-	if ( empty( $levels ) ) {
-		return $access;
-	}
-
-	//now we need to check if the user is approved for ANY of the $levels
+	// Check if user is paused.
 	$paused_user = get_user_meta( $user->ID, 'pmpro_paused_user', true );
 	if ( ! empty( $paused_user ) ) {
 		$access = false;
@@ -82,45 +62,36 @@ function paused_member_pmpro_has_membership_access_filter( $access, $post, $user
 add_filter( 'pmpro_has_membership_access_filter', 'paused_member_pmpro_has_membership_access_filter', 10, 4 );
 
 /**
- * Show a different message for users that have their membership paused.
+ * Show a different no-access message for users with paused membership.
  */
+function paused_member_pmpro_no_access_message_body( $body, $level_ids ) {
+	global $current_user;
 
-function paused_member_pmpro_non_member_text_filter( $text ) {
-
-	global $current_user, $has_access;
-
-	//get current user's level ID
+	// Check if the current user is paused.
 	$paused_user = get_user_meta( $current_user->ID, 'pmpro_paused_user', true );
-
-	//if a user does not have a membership level, return default text.
 	if ( ! empty( $paused_user ) ) {
-		$text = __( '<p>Your membership is paused. Please contact us to reinstate your membership.</p><a href="/contact/">Contact Us</a>', 'paid-memberships-pro' );
+		$body = __( '<p>Your membership is paused. Please contact us to reinstate your membership.</p><a href="/contact/">Contact Us</a>', 'paid-memberships-pro' );
 	}
 
-	return $text;
+	return $body;
 }
-
-add_filter( 'pmpro_non_member_text_filter', 'paused_member_pmpro_non_member_text_filter' );
+add_filter( 'pmpro_no_access_message_body', 'paused_member_pmpro_no_access_message_body', 10, 2 );
 
 /**
- * Filter the content of the Membership Account page to show message to paused user.
- *
+ * Show a message on the Membership Account page for paused members.
  */
-
 function paused_member_pmpro_membership_account_filter( $content ) {
 	global $pmpro_pages, $current_user;
 
-	// Check if current user is paused.
-	if ( is_user_logged_in() ) {
+	if ( is_user_logged_in() && is_page( $pmpro_pages['account'] ) ) {
 		$paused_user = get_user_meta( $current_user->ID, 'pmpro_paused_user', true );
+		if ( ! empty( $paused_user ) ) {
+			// Message to show on the account page.
+			$new_content = __( '<div class="pmpro_content_message"><p>Your membership is paused. Please contact us to reinstate your membership.</p><a href="/contact/">Contact Us</a></div>', 'paid-memberships-pro' );
+			$content = $new_content . $content;
+		}
 	}
 
-	if ( is_page( $pmpro_pages[ 'account' ] ) && ! empty( $paused_user ) ) {
-        //Change wording to something of your preference
-		$newcontent = __( '<div class="pmpro_content_message"><p>Your membership is paused. Please contact us to reinstate your membership.</p><a href="/contact/">Contact Us</a></div>', 'paid-memberships-pro' );
-		$content = $newcontent . $content;
-	}
 	return $content;
 }
-
 add_filter( 'the_content', 'paused_member_pmpro_membership_account_filter', 10 );


### PR DESCRIPTION
pmpro_non_member_text_filter is deprecated since version 3.1! This updated recipe uses the recommended pmpro_no_access_message_body filter instead.