### PR TITLE
Update add-level-name-checkout-attribute-seo.php

### DIFF
--- a/frontend-pages/add-level-name-checkout-attribute-seo.php
+++ b/frontend-pages/add-level-name-checkout-attribute-seo.php
@@ -13,12 +13,13 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-function my_pmpro_membership_checkout_head_title( $title, $sep ) {
-	global $pmpro_pages;
-	if ( ! empty( $pmpro_pages ) && is_page( $pmpro_pages['checkout'] ) ) {
-		global $pmpro_level;
-		$title = $pmpro_level->name . ' ' . $sep . ' ' . $title;
+function my_pmpro_membership_checkout_title_parts( $title_parts ) {
+	global $pmpro_pages, $pmpro_level;
+
+	if ( ! empty( $pmpro_pages ) && is_page( $pmpro_pages['checkout'] ) && ! empty( $pmpro_level ) ) {
+		$title_parts['title'] = $pmpro_level->name . ' – ' . $title_parts['title'];
 	}
-	return $title;
+
+	return $title_parts;
 }
-add_filter( 'wp_title', 'my_pmpro_membership_checkout_head_title', 20, 2 );
+add_filter( 'document_title_parts', 'my_pmpro_membership_checkout_title_parts', 20 );


### PR DESCRIPTION
The original snippet uses the `wp_title` filter, which may not apply in modern themes. This version uses the `document_title_parts` filter, which is commonly supported in modern themes and already used in parts of the PMPro core.