### PR TITLE
Update remove-element-from-default-dimensions-array.php

### DIFF
--- a/add-ons/pmpro-google-analytics/remove-element-from-default-dimensions-array.php
+++ b/add-ons/pmpro-google-analytics/remove-element-from-default-dimensions-array.php
@@ -21,9 +21,9 @@
  * @return array $dimensions The customized dimensions array.
  */
 function my_pmproga4_default_custom_dimension( $dimensions ) {
-	// Remove the category dimension. Change the unset dimensiion as needed.
-	unset( $dimension['category'] );
+	// Remove the category dimension. Change the unset dimensions as needed.
+	unset( $dimensions['category'] );
+	
 	return $dimensions;
 }
-
 add_filter( 'pmproga4_default_custom_dimension', 'my_pmproga4_default_custom_dimension' );


### PR DESCRIPTION
The existing snippet was throwing a `Warning: Undefined variable $dimension` error, which resulted from a typo on line 25. This PR update resolves this error.