### PR TITLE
Updating the recipe to change membership level on expiration only

### DIFF
--- a/membership-levels/change-membership-level-on-expiration-only.php
+++ b/membership-levels/change-membership-level-on-expiration-only.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Change Membership Level on Expiration Only
- * Users who manually cancel are cancelled immediately, but users who expire are given a grace period.
  * 
  * title: Change Membership Level on Expiration Only
  * layout: snippet
@@ -13,9 +12,13 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
- function my_pmpro_set_default_level_only_when_expiring( $user_id, $level_id ) {
+function my_pmpro_set_default_level_only_when_expiring( $user_id, $level_id ) {
+	global $pmpro_next_payment_timestamp;
 
-	pmpro_changeMembershipLevel( 1, $user_id ); // Change this to the level ID you want to give expired members.
+	// Only change the level if there is no future payment scheduled.
+	if ( empty( $pmpro_next_payment_timestamp ) ) {
+		pmpro_changeMembershipLevel( 1, $user_id ); // Change this to the level ID you want to give expired members.
+	}
 
 	return $user_id;
 }

--- a/membership-levels/change-membership-level-on-expiration-only.php
+++ b/membership-levels/change-membership-level-on-expiration-only.php
@@ -7,6 +7,7 @@
  * layout: snippet
  * collection: membership-levels
  * category: expiration
+ * link: https://www.paidmembershipspro.com/change-membership-level-on-cancellation-or-expiration/
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.

--- a/membership-levels/change-membership-level-on-expiration-only.php
+++ b/membership-levels/change-membership-level-on-expiration-only.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Change Membership Level on Expiration Only
+ * Users who manually cancel are cancelled immediately
  * 
  * title: Change Membership Level on Expiration Only
  * layout: snippet


### PR DESCRIPTION
The previous recipe was no longer working to change the level on expiration. If the member canceled their membership on the old recipe, the level was canceled immediately. With this updated recipe, a user canceling a subscription will get an expiration date, and when it expires, they are downgraded to the set free level.