### PR TITLE
Update the code to hide billing address for specific levels at checkout

### DIFF
--- a/add-ons/pmpro-address-for-free-levels/hide-billing-fields-for-some.php
+++ b/add-ons/pmpro-address-for-free-levels/hide-billing-fields-for-some.php
@@ -14,18 +14,17 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
- function my_pmpro_hide_billing_fields_for_levels() {
-
-	$levels_to_hide = array( 1,3,5 ); //change level ID's you want to hide billing fields from.
+function my_pmpro_hide_billing_fields_for_levels() {
+	$levels_to_hide = array( 1, 3, 5 ); // Change these to match your level IDs.
 	$level = pmpro_getLevelAtCheckout();
-	
-	if ( in_array( $level, $levels_to_hide ) ) {
+
+	if ( is_object( $level ) && isset( $level->id ) && in_array( (int) $level->id, $levels_to_hide, true ) ) {
 		remove_action( 'init', 'pmproaffl_init_include_address_fields_at_checkout', 30 );
 		remove_action( 'pmpro_checkout_boxes', 'pmproaffl_pmpro_checkout_boxes_require_address' );
-		remove_action( 'pmpro_required_billing_fields', 'pmproaffl_pmpro_required_billing_fields', 30);
+		remove_action( 'pmpro_required_billing_fields', 'pmproaffl_pmpro_required_billing_fields', 30 );
 		remove_action( 'pmpro_paypalexpress_session_vars', 'pmproaffl_pmpro_paypalexpress_session_vars' );
-		remove_action( 'pmpro_before_send_to_twocheckout', 'pmproaffl_pmpro_paypalexpress_session_vars', 10, 2);
-		remove_action( 'pmpro_checkout_before_change_membership_level', 'pmproaffl_pmpro_checkout_before_change_membership_level', 5, 2);
+		remove_action( 'pmpro_before_send_to_twocheckout', 'pmproaffl_pmpro_paypalexpress_session_vars', 10, 2 );
+		remove_action( 'pmpro_checkout_before_change_membership_level', 'pmproaffl_pmpro_checkout_before_change_membership_level', 5, 2 );
 		remove_action( 'pmpro_checkout_preheader', 'pmproaffl_init_load_session_vars', 5 );
 		remove_filter( 'pmpro_checkout_order_free', 'pmproaffl_pmpro_checkout_order_free' );
 	}


### PR DESCRIPTION
Tightened compliance with WPCS.
Resolved the "Notice: Object of class stdClass could not be converted to int." error in the existing snippet Prevent subtle bugs when the $level is not an object.