### PR TITLE
Update remove subscription delay for current and past members

### DIFF
--- a/add-ons/pmpro-subscription-delays/remove-subscription-delay-for-members.php
+++ b/add-ons/pmpro-subscription-delays/remove-subscription-delay-for-members.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * Remove subscription delay for current or past members. 
- * This code stores data when a user checks out for a level. 
+ * Remove subscription delay for logged-in current or past members. 
  * If that user tries to check out for the same level, the Subscription Delay is removed. 
  * The user is instead charged for their first subscription payment at checkout.
  *

--- a/add-ons/pmpro-subscription-delays/remove-subscription-delay-for-members.php
+++ b/add-ons/pmpro-subscription-delays/remove-subscription-delay-for-members.php
@@ -1,6 +1,9 @@
 <?php
 /**
- * Remove subscription delay for current or past members. This will remove all subscription delays from checkout for any level if the user is an active member or had a prior level (and is renewing).
+ * Remove subscription delay for current or past members. 
+ * This code stores data when a user checks out for a level. 
+ * If that user tries to check out for the same level, the Subscription Delay is removed. 
+ * The user is instead charged for their first subscription payment at checkout.
  *
  * title: Subscription Delay that can only be used once.
  * layout: snippet
@@ -12,32 +15,36 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-function my_pmpro_remove_subscription_delay_for_members() {
+function my_pmpro_one_time_sub_delay( $checkout_level ) {
 
-	// Do not run this code for logged-out users or while in the WordPress dashboard.
-	if ( is_admin() || ! is_user_logged_in() ) {
-		return;
+	// Logged-out users should always get the trial.
+	if ( ! is_user_logged_in() ) {
+		return $checkout_level;
 	}
 
-	// Check if the user has any old levels at any point in time.
-	$prev_member = false;
-	if ( ! pmpro_hasMembershipLevel() && is_user_logged_in() ) {
-		$order = new MemberOrder();
-		$lastorder = $order->getLastMemberOrder( NULL, array( 'success', 'cancelled' ));
-			if ( ! empty( $lastorder ) ) {
-				$prev_member = true;
-			}
-	}
+	$order     = new MemberOrder();
+	$lastorder = $order->getLastMemberOrder( null, array( 'success', 'cancelled' ) );
+	$has_delay = get_option( 'pmpro_subscription_delay_' . $checkout_level->id, '' );
 
-	// If user currently has a membership level or previously had a membership level, remove custom trial.
-	if ( pmpro_hasMembershipLevel() || $prev_member ) {
-		//for backwards compatibility with PMPro < 3.4
+	// If user currently has a membership level or previously had a membership level, remove subscription delay.
+	if ( ( pmpro_hasMembershipLevel() || ! empty( $lastorder ) ) && ! empty( $has_delay ) ) {
+
+		// Remove subscription delay filters and actions (standard).
 		remove_filter( 'pmpro_profile_start_date', 'pmprosd_pmpro_profile_start_date', 10, 2 );
-		remove_filter( 'pmpro_checkout_level', 'pmprosd_pmpro_checkout_level' ); //for PMPro 3.4+
 		remove_action( 'pmpro_after_checkout', 'pmprosd_pmpro_after_checkout' );
 		remove_filter( 'pmpro_next_payment', 'pmprosd_pmpro_next_payment', 10, 3 );
 		remove_filter( 'pmpro_level_cost_text', 'pmprosd_level_cost_text', 10, 2 );
 		remove_action( 'pmpro_save_discount_code_level', 'pmprosd_pmpro_save_discount_code_level', 10, 2 );
+
+		// Remove the updated filter added in PMPro Subscription Delays 3.4+.
+		remove_filter( 'pmpro_checkout_level', 'pmprosd_pmpro_checkout_level', 10, 2 );
+
+		// Set the initial amount to match the billing amount.
+		if ( $checkout_level->billing_amount > 0 ) {
+			$checkout_level->initial_payment = $checkout_level->billing_amount;
+		}
 	}
+
+	return $checkout_level;
 }
-add_filter( 'init', 'my_pmpro_remove_subscription_delay_for_members' );
+add_filter( 'pmpro_checkout_level', 'my_pmpro_one_time_sub_delay' );


### PR DESCRIPTION
An update to the existing snippet that also checks if the level has a subscription delay and works with Stripe checkout, showing the correct level cost text.