### PR TITLE
Refactor user level ID checks.

### DIFF
--- a/add-ons/pmpro-woocommerce/set-ebook-category-member-price-to-free.php
+++ b/add-ons/pmpro-woocommerce/set-ebook-category-member-price-to-free.php
@@ -7,6 +7,7 @@
  * layout: snippet
  * collection: add-ons
  * category: pmpro-woocommerce
+ * link: https://www.paidmembershipspro.com/woocommerce-specific-category-free-for-members/
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.

--- a/add-ons/pmpro-woocommerce/set-ebook-category-member-price-to-free.php
+++ b/add-ons/pmpro-woocommerce/set-ebook-category-member-price-to-free.php
@@ -16,26 +16,28 @@
  */
 
 function my_pmprowoo_get_membership_price_ebooks_category( $discount_price, $level_id, $original_price, $product ) {
+	// Get all membership levels for the current user and extract their IDs into an array.
+	$user_levels = pmpro_getMembershipLevelsForUser( get_current_user_id() );
+	$level_ids   = ! empty( $user_levels ) && is_array( $user_levels ) ? wp_list_pluck( $user_levels, 'id' ) : array();
+
 	// Return early if the user does not have a membership level.
-	// Adjust this or add additional checks to require a specific membership level.
-	if ( empty( $level_id ) ) {
+	if ( empty( $level_ids ) ) {
 		return $discount_price;
 	}
 
-	// Use this code to check a specific level the user has (or is buying) level 1.
-	// if ( $level_id != 1 ) {
-	//	return $discount_price;
+	// Uncomment to require a specific membership level.
+	// if ( ! in_array( 1, $level_ids ) ) {
+	// 	return $discount_price;
 	// }
 
 	// Set array of categories that are "free". Add additional category slugs as needed.
 	$free_product_cats = array( 'ebooks' );
 
-	// Check if the product is in the Ebook category and set price to 0 for all members.
+	// Check if the product is in the free categories
 	if ( has_term( $free_product_cats, 'product_cat', $product->get_id() ) ) {
 		$discount_price = 0;
 	}
 
-	// Return the discounted price.
 	return $discount_price;
 }
 add_filter( 'pmprowoo_get_membership_price', 'my_pmprowoo_get_membership_price_ebooks_category', 10, 4 );

--- a/add-ons/pmpro-woocommerce/set-ebook-category-member-price-to-free.php
+++ b/add-ons/pmpro-woocommerce/set-ebook-category-member-price-to-free.php
@@ -38,6 +38,7 @@ function my_pmprowoo_get_membership_price_ebooks_category( $discount_price, $lev
 		$discount_price = 0;
 	}
 
+	// Return the discounted price.
 	return $discount_price;
 }
 add_filter( 'pmprowoo_get_membership_price', 'my_pmprowoo_get_membership_price_ebooks_category', 10, 4 );


### PR DESCRIPTION
The previously used `$level_id` parameter returns the level_id of product discounts sets for membership levels in the Memberships tab of the WC product edit page and not the user's level ID(s). Now getting level IDs for user using the `pmpro_getMembershipLevelsForUser` function. 