### PR TITLE
Fix PHP warning in show-affiliate-level-in-admin-list.php

### DIFF
--- a/add-ons/pmpro-affiliates/show-affiliate-level-in-admin-list.php
+++ b/add-ons/pmpro-affiliates/show-affiliate-level-in-admin-list.php
@@ -2,12 +2,12 @@
 /**
  * Add a column to show the active membership level for the affiliate on the
  * Memberships > Affiliates list in the WordPress admin.
- * Learn more at https://www.paidmembershipspro.com/lightweight-affiliates-add-column/
  *
  * title: Show Affiliate's Membership Level on Admin Page
  * layout: snippet
  * collection: add-ons
  * category: pmpro-affiliates
+ * link: https://www.paidmembershipspro.com/lightweight-affiliates-add-column/
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
@@ -26,7 +26,7 @@ add_action( 'pmpro_affiliate_extra_cols_header', 'my_pmpro_affiliate_extra_cols_
 /**
  * Add membership level row data for each affiliate.
  */
-function my_pmpro_affiliate_extra_cols_body_level( $affiliate, $earnings) {
+function my_pmpro_affiliate_extra_cols_body_level( $affiliate, $earnings ) {
 	// Get the user for this affiliate.
 	$user = get_user_by( 'login', $affiliate->affiliateuser );
 
@@ -37,8 +37,11 @@ function my_pmpro_affiliate_extra_cols_body_level( $affiliate, $earnings) {
 	}
 
 	// Show the level name or return a blank/missing character if no membership.
-	$membership_level = pmpro_getMembershipLevelForUser($user->ID);
-	echo '<td>' . ( $membership_level->name ?: '&#8212;' ) . '</td>';
-
+	$membership_level = pmpro_getMembershipLevelForUser( $user->ID );
+	if ( ! empty( $membership_level ) ) {
+		echo '<td>' . esc_html( $membership_level->name ) . '</td>';
+	} else {
+		echo '<td>&#8212;</td>';
+	}
 }
 add_action( 'pmpro_affiliate_extra_cols_body', 'my_pmpro_affiliate_extra_cols_body_level', 10, 2 );


### PR DESCRIPTION
Fixes a warning that would be generated if an affiliate does not have a membership level.

Some WPCS changes.