### PR TITLE
Update load-custom-TOS-by-level.php

### DIFF
--- a/checkout/load-custom-TOS-by-level.php
+++ b/checkout/load-custom-TOS-by-level.php
@@ -1,13 +1,13 @@
 <?php
 /**
  * Show a Different “Terms of Service” at Checkout Based on Membership Level
- * 
+ *
  * title: Show a Different TOS at Checkout Based on Membership Level
  * layout: snippet
  * collection: checkout
  * category: tos, levels
  * link:https://www.paidmembershipspro.com/show-different-terms-service-checkout-based-membership-level/
- * 
+ *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
  * Read this companion article for step-by-step directions on either method.
@@ -19,17 +19,20 @@
  * Change the Terms of Service page based on the membership level.
  */
 function my_option_pmpro_tospage( $tospage ) {
-	global $pmpro_level;
-
-	// Check if $pmpro_level is set and is an object
-	if ( !empty( $pmpro_level ) && isset( $pmpro_level->id ) ) {
-		if ( $pmpro_level->id == 1 ) {
-			$tospage = 53; // change this
-		} else {
-			$tospage = 55;
-		}
+	// Only run this logic on the checkout page.
+	if ( ! function_exists( 'pmpro_is_checkout' ) || ! pmpro_is_checkout() ) {
+		return $tospage;
 	}
 
+	// Get level object at checkout.
+	$level = pmpro_getLevelAtCheckout();
+
+	// If the level at checkout is 1, use the specific TOS page.
+	if ( ! empty( $level ) && $level->id == 1 ) {
+		$tospage = 27; // Page ID for Level 1 TOS.
+	}
+
+	// For all other levels, we don't do anything and return the default TOS page ID.
 	return $tospage;
 }
 add_filter( 'option_pmpro_tospage', 'my_option_pmpro_tospage' );

--- a/checkout/load-custom-TOS-by-level.php
+++ b/checkout/load-custom-TOS-by-level.php
@@ -29,7 +29,13 @@ function my_option_pmpro_tospage( $tospage ) {
 
 	// If the level at checkout is 1, use the specific TOS page.
 	if ( ! empty( $level ) && $level->id == 1 ) {
-		$tospage = 27; // Page ID for Level 1 TOS.
+		// Page ID for Level 1 TOS.
+		$custom_tospage_id = 27; // Change this to the ID of your custom TOS page.
+
+		// Check if the custom TOS page is a valid, published page.
+		if ( get_post_status( $custom_tospage_id ) === 'publish' ) {
+			$tospage = $custom_tospage_id;
+		}
 	}
 
 	// For all other levels, we don't do anything and return the default TOS page ID.


### PR DESCRIPTION
- Refactored to use modern PMPro functions to determine the level at checkout to ensure we have a level if and when the global `$pmpro_level` variable is not available.
- Added a conditional check to ensure the custom TOS page is available as a published page before returning the custom TOS page ID.