### PR TITLE
Update limit-posts-pmpro-series.php

### DIFF
--- a/add-ons/pmpro-series/limit-posts-pmpro-series.php
+++ b/add-ons/pmpro-series/limit-posts-pmpro-series.php
@@ -24,10 +24,10 @@ function my_pmpro_series_limit_posts_shown( $post_list, $series_object ) {
 	$posts_to_display = array();
 
 	foreach ( $post_list as $sp ) {
-		$posts_to_display[] = $sp;
 		if ( max( 0, $member_days ) < $sp->delay ) {
 			break;
 		}
+		$posts_to_display[] = $sp;		
 	}
 	
 	return $posts_to_display;


### PR DESCRIPTION
The upcoming series item would always be displayed.
This change ensures that only the series items that the user can access are shown. 