### PR TITLE
Send Admin Change email to members added via Zapier

### DIFF
--- a/add-ons/pmpro-zapier/send-admin-change-email-after-add-member.php
+++ b/add-ons/pmpro-zapier/send-admin-change-email-after-add-member.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Send PMPro admin change email after registering a member through a PMPro Zapier zap.
+ *
+ * title: Send the Admin Change Email to Members Added via Zapier
+ * layout: snippet
+ * collection: add-ons
+ * category: email
+ * link: https://www.paidmembershipspro.com/send-signup-emails-to-zapier-added-pmpro-members/
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function my_pmproz_send_admin_change_email_after_add_member( $user_id, $level_id ){
+	$user = get_userdata( $user_id );
+	$pmpro_email = new PMProEmail();
+	$pmpro_email->sendAdminChangeEmail( $user );
+}
+add_action( 'pmproz_after_add_member', 'my_pmproz_send_admin_change_email_after_add_member', 10, 2 );

--- a/add-ons/pmpro-zapier/send-admin-change-email-after-add-member.php
+++ b/add-ons/pmpro-zapier/send-admin-change-email-after-add-member.php
@@ -13,9 +13,9 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-function my_pmproz_send_admin_change_email_after_add_member( $user_id, $level_id ){
+function my_pmproz_after_add_member_send_admin_change_email( $user_id, $level_id ){
 	$user = get_userdata( $user_id );
 	$pmpro_email = new PMProEmail();
 	$pmpro_email->sendAdminChangeEmail( $user );
 }
-add_action( 'pmproz_after_add_member', 'my_pmproz_send_admin_change_email_after_add_member', 10, 2 );
+add_action( 'pmproz_after_add_member', 'my_pmproz_after_add_member_send_admin_change_email', 10, 2 );


### PR DESCRIPTION
This updated snippet is part of a rewrite of the following article: https://www.paidmembershipspro.com/send-signup-emails-to-zapier-added-pmpro-members/

The [original snippet](https://gist.github.com/travislima/de47dc5e143b1c0345bcce5e1c01b528#file-pmprozapier_email_after_change_level-php) would cause the new user notification to be sent twice. This updated snippet drops the call to `wp_new_user_notification()` as recent versions of the Zapier Add On already trigger this email when a new member is added.

The Zapier Add On now includes a `pmproz_after_add_member` hook that can be used to perform actions when a member is added via Zapier specifically. This snippet uses this hook instead of `pmpro_after_change_membership_level` to send the admin change email.