### PR TITLE
Update add-mycred-points-at-checkout.php

### DIFF
--- a/frontend-pages/add-mycred-points-at-checkout.php
+++ b/frontend-pages/add-mycred-points-at-checkout.php
@@ -23,19 +23,18 @@ function add_my_cred_to_pmpro_checkout( $user_id, $morder ) {
 		return;
 	}
 
-	// Get the user's level and expiration date.
-	$level = pmpro_getMembershipLevelForUser( $user_id );
-	$level_expiration = $level->enddate;
+	// Get the level associated with this checkout.
+	$level = $morder->getMembershipLevel();
 
-	// Add these lines to give points to recurring members only.
-	if ( ! empty( $level->enddate ) ) {
-		return;
-	}
+	// Uncomment these lines to give points for recurring membership checkouts only.
+	// if ( ! pmpro_isLevelRecurring( $level ) ) {
+	//  return;
+	// }
 
     $points = 10; // default to 10 points. If level ID is blank 10 points would be awarded.
     $reference = 'Successful Membership Payment';
-    $entry = 'Paid Memberships Pro - level: ' . $level->ID;
-    switch( $level->ID ) {
+    $entry = 'Paid Memberships Pro - level: ' . $level->id;
+    switch( $level->id ) {
         case 1:
             $points = 20;
             break;


### PR DESCRIPTION
Getting the level from the order object instead of `pmpro_getMembershipLevelForUser` which can return a level other than the one just purchased.

Using `pmpro_isLevelRecurring` to check if the level is recurring instead of checking for an enddate on the level object.

Commenting out the lines that make the snippet assign points for recurring memberships only. Reason, the article talks of assigning points for every checkout and mentions that assigning points for recurring membership checkouts is an optional customization. 
> This recipe awards[ MyCRED](https://wordpress.org/plugins/mycred/) points upon the initial membership checkout. Optionally, you can set it up to reward only members who choose automatic renewal, complementing the[ Auto-Renewal Checkbox at Membership Checkout Add On](https://www.paidmembershipspro.com/add-ons/auto-renewal-checkbox-membership-checkout/).

Replacing `ID` key with `id`. The level object returned by `$morder->getMembershipLevel()` includes only `id`.
