### PR TITLE
Update require-custom-level-group-elementor.php

### DIFF
--- a/integration-compatibility/require-custom-level-group-elementor.php
+++ b/integration-compatibility/require-custom-level-group-elementor.php
@@ -7,6 +7,7 @@
  * layout: snippet
  * collection: integration-compatibility
  * category: content, restriction, elementor
+ * link: https://www.paidmembershipspro.com/group-levels-elementor/
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
@@ -15,30 +16,77 @@
  */
 
 /**
+ * Define levels for the custom group of levels.
+ */
+global $pmpro_elementor_group_levels;
+$pmpro_elementor_group_levels = array( 1, 2, 3 );
+
+/**
  * Add the "My Custom Levels Group" item to the PMPro field in Elementor editor.
  */
 function my_pmpro_elementor_levels_array_custom( $levels ) {
-    // Add a new selection to the Require Membership Level advanced setting in Elementor.
-    $levels['my_pmpro_elementor_custom_levels'] = __( 'My Custom Levels Group' );
+	// Add a new selection to the Require Membership Level advanced setting in Elementor.
+	$levels['my_pmpro_elementor_custom_levels'] = __( 'My Custom Levels Group' );
 
-    // Return the array of items for the dropdown with our new item added.
-    return $levels;
+	// Return the array of items for the dropdown with our new item added.
+	return $levels;
 }
 add_filter( 'pmpro_elementor_levels_array', 'my_pmpro_elementor_levels_array_custom', 10, 1 );
 
 /**
- * Check the custom setting against our specific level IDs before showing content.
+ * Callback to check the custom setting against our levels group before showing content for PMPro < v3.5.
  */
 function my_pmpro_elementor_has_access_custom( $access, $element, $restricted_levels ) {
-    // Check if the element is restricted for our custom level group item.
-    if ( in_array( 'my_pmpro_elementor_custom_levels', $restricted_levels ) ) {
-        // Require membership level IDs 1, 2, or 3 to view this content.
-        if ( pmpro_hasMembershipLevel( array( 1, 2, 3 ) ) ) {
-            return true;
-        }
-    }
+	global $pmpro_elementor_group_levels;
+	// Check if the element is restricted for our custom level group item.
+	if ( in_array( 'my_pmpro_elementor_custom_levels', $restricted_levels ) ) {
+		// Require a membership level from our custom group to view this content.
+		if ( pmpro_hasMembershipLevel( $pmpro_elementor_group_levels ) ) {
+			return true;
+		}
+	}
 
-    // Return whether the user has access to this content.
-    return $access;
+	// Return whether the user has access to this content.
+	return $access;
 }
-add_action( 'pmpro_elementor_has_access', 'my_pmpro_elementor_has_access_custom', 10, 3 );
+
+/**
+ * Callback to check the custom setting against our levels group before showing content for PMPro v3.5+.
+ */
+function my_pmpro_elementor_has_membership_level_custom( $has_level, $user_id, $levels ) {
+	global $pmpro_elementor_group_levels;
+	// Bail if the user has access already.
+	if ( $has_level ) {
+		return $has_level;
+	}
+
+	// Bail if our custom level group item is not in the required levels.
+	if ( ! in_array( 'my_pmpro_elementor_custom_levels', $levels ) ) {
+		return $has_level;
+	}
+
+	// Require a membership level from our custom group to view this content.
+	if ( pmpro_hasMembershipLevel( $pmpro_elementor_group_levels ) ) {
+		$has_level = true;
+	}
+
+	return $has_level;
+}
+
+/**
+ * Hook into pmpro_has_membership_level if running PMPro v3.5+.
+ * Otherwise, hook into pmpro_elementor_has_access.
+ */
+function my_pmpro_hook_elementor_access_filters() {
+	// If PMPRO_VERSION is not defined, bail.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
+	if ( version_compare( PMPRO_VERSION, '3.5', '>=' ) ) {
+		add_filter( 'pmpro_has_membership_level', 'my_pmpro_elementor_has_membership_level_custom', 10, 3 );
+	} else {
+		add_filter( 'pmpro_elementor_has_access', 'my_pmpro_elementor_has_access_custom', 10, 3 );
+	}
+}
+add_action( 'init', 'my_pmpro_hook_elementor_access_filters' );


### PR DESCRIPTION
The `pmpro_elementor_has_access` method was deprecated in PMPro v3.5.
This adds support for PMPro v3.5+ while maintaining backwards compatibility.
