### PR TITLE
update the snippet to override default failed map notice with new filter

### DIFF
--- a/add-ons/pmpro-member-directory/override-default-map-notice.php
+++ b/add-ons/pmpro-member-directory/override-default-map-notice.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Override the default "map failed to load" notice in PMPro Member Directory.
+ * 
+ * title: Override Map Failed Notice for Member Directory Map
+ * layout: snippet
+ * collection: pmpro-member-directory
+ * category: maps, directory, profile
+ * link: https://www.paidmembershipspro.com/overriding-the-default-membership-maps-error-message/
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function mypmpromm_override_default_map_notice( $notice ) {
+	return;
+}
+add_filter( 'pmpromd_map_failed_to_load_notice', 'mypmpromm_override_default_map_notice', 10, 1 );


### PR DESCRIPTION
Updated the title and layout in the PHP file for overriding the default map notice in the PMPro Member Directory.

And updated the filter to the new member directory maps filter for this.