### PR TITLE
Change who get's PMPro admin emails

### DIFF
--- a/email/change-who-receives-pmpro-admin-emails.php
+++ b/email/change-who-receives-pmpro-admin-emails.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Change the recipient and optionally add a BCC for all admin-related emails in Paid Memberships Pro.
+ * Change the recipient for all admin-related emails in Paid Memberships Pro.
  *
- * title: Change Admin Email Recipient and Add BCC
+ * title: Change Admin Email Recipient for PMPro Admin emails.
  * layout: snippet
  * collection: email
- * category: admin, bcc
+ * category: admin
  * link: TBD
  *
  * You can add this recipe to your site by creating a custom plugin
@@ -13,35 +13,11 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-
-/**
- * SETTINGS
- */
-define( 'MY_PMPRO_ADMIN_EMAIL_TO', 'memberadmin@someemail.co' );
-// define( 'MY_PMPRO_ADMIN_EMAIL_BCC', 'bccaddress@someemail.co' );
-
 function my_pmpro_change_admin_email_recipients( $user_email, $email ) {
-	// Only target admin-related PMPro emails.
-	if ( strpos( $email->template, '_admin' ) === false ) {
-		return $user_email;
-	}
+	if ( strpos( $email->template, "_admin" ) !== false ) {
+		$user_email = 'memberadmin@someemail.co'; // Change your email address here.
+    }
 
-	return MY_PMPRO_ADMIN_EMAIL_TO;
+	return $user_email;
 }
 add_filter( 'pmpro_email_recipient', 'my_pmpro_change_admin_email_recipients', 10, 2 );
-
-function my_pmpro_add_admin_email_bcc( $headers, $email ) {
-	// Only target admin-related PMPro emails.
-	if ( strpos( $email->template, '_admin' ) === false ) {
-		return $headers;
-	}
-
-	// Skip if BCC is not defined.
-	if ( ! defined( 'MY_PMPRO_ADMIN_EMAIL_BCC' ) ) {
-		return $headers;
-	}
-
-	$headers[] = 'Bcc: ' . MY_PMPRO_ADMIN_EMAIL_BCC;
-	return $headers;
-}
-add_filter( 'pmpro_email_headers', 'my_pmpro_add_admin_email_bcc', 10, 2 );

--- a/email/change-who-receives-pmpro-admin-emails.php
+++ b/email/change-who-receives-pmpro-admin-emails.php
@@ -4,7 +4,7 @@
  *
  * title: Change Admin Email Recipient and Add BCC
  * layout: snippet
- * collection: email-notifications
+ * collection: email
  * category: admin, bcc
  * link: TBD
  *

--- a/email/change-who-receives-pmpro-admin-emails.php
+++ b/email/change-who-receives-pmpro-admin-emails.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Change the recipient and optionally add a BCC for all admin-related emails in Paid Memberships Pro.
+ *
+ * title: Change Admin Email Recipient and Add BCC
+ * layout: snippet-example
+ * collection: email-notifications
+ * category: admin-emails
+ * link: TBD
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * SETTINGS
+ */
+define( 'MY_PMPRO_ADMIN_EMAIL_TO', 'memberadmin@someemail.co' );
+// define( 'MY_PMPRO_ADMIN_EMAIL_BCC', 'bccaddress@someemail.co' );
+
+function my_pmpro_change_admin_email_recipients( $user_email, $email ) {
+	// Only target admin-related PMPro emails.
+	if ( strpos( $email->template, '_admin' ) === false ) {
+		return $user_email;
+	}
+
+	return MY_PMPRO_ADMIN_EMAIL_TO;
+}
+add_filter( 'pmpro_email_recipient', 'my_pmpro_change_admin_email_recipients', 10, 2 );
+
+function my_pmpro_add_admin_email_bcc( $headers, $email ) {
+	// Only target admin-related PMPro emails.
+	if ( strpos( $email->template, '_admin' ) === false ) {
+		return $headers;
+	}
+
+	// Skip if BCC is not defined.
+	if ( ! defined( 'MY_PMPRO_ADMIN_EMAIL_BCC' ) ) {
+		return $headers;
+	}
+
+	$headers[] = 'Bcc: ' . MY_PMPRO_ADMIN_EMAIL_BCC;
+	return $headers;
+}
+add_filter( 'pmpro_email_headers', 'my_pmpro_add_admin_email_bcc', 10, 2 );

--- a/email/change-who-receives-pmpro-admin-emails.php
+++ b/email/change-who-receives-pmpro-admin-emails.php
@@ -3,7 +3,7 @@
  * Change the recipient and optionally add a BCC for all admin-related emails in Paid Memberships Pro.
  *
  * title: Change Admin Email Recipient and Add BCC
- * layout: snippet-example
+ * layout: snippet
  * collection: email-notifications
  * category: admin, bcc
  * link: TBD

--- a/email/change-who-receives-pmpro-admin-emails.php
+++ b/email/change-who-receives-pmpro-admin-emails.php
@@ -5,7 +5,7 @@
  * title: Change Admin Email Recipient and Add BCC
  * layout: snippet-example
  * collection: email-notifications
- * category: admin-emails
+ * category: admin, bcc
  * link: TBD
  *
  * You can add this recipe to your site by creating a custom plugin


### PR DESCRIPTION
by default the site admin gets these, with this recipe you can Change the default And set BCC if you need too.