### PR TITLE
Add load scripts to PMPro pages

### DIFF
--- a/frontend-pages/load-scripts-on-checkout-and-confirmation-pages.php
+++ b/frontend-pages/load-scripts-on-checkout-and-confirmation-pages.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Load scripts or styles on PMPro checkout and confirmation pages.
+ *
+ * title: Load Scripts or Styles to the PMPro Pages of your Membership Site
+ * layout: snippet
+ * collection: frontend-pages
+ * category: content
+ * link: https://www.paidmembershipspro.com/load-javascript-scripts-pmpro-pages/
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function load_my_script_for_pmpro_pages() {
+	global $pmpro_pages;
+
+	if ( empty( $pmpro_pages ) ) {
+		return;
+	}
+
+	if ( is_page( $pmpro_pages['checkout'] ) || is_page( $pmpro_pages['confirmation'] ) ) {
+		?>
+			<!-- scripts or styles go here -->
+		<?php
+	}
+}
+add_action( 'wp_head', 'load_my_script_for_pmpro_pages' );

--- a/frontend-pages/load-scripts-on-checkout-and-confirmation-pages.php
+++ b/frontend-pages/load-scripts-on-checkout-and-confirmation-pages.php
@@ -20,7 +20,11 @@ function load_my_script_for_pmpro_pages() {
 		return;
 	}
 
-	if ( is_page( $pmpro_pages['checkout'] ) || is_page( $pmpro_pages['confirmation'] ) ) {
+	if ( ! function_exists( 'pmpro_is_checkout' ) ) {
+		return;
+	}
+
+	if ( pmpro_is_checkout() || is_page( $pmpro_pages['confirmation'] ) ) {
 		?>
 			<!-- scripts or styles go here -->
 		<?php

--- a/frontend-pages/load-scripts-on-checkout-and-confirmation-pages.php
+++ b/frontend-pages/load-scripts-on-checkout-and-confirmation-pages.php
@@ -13,13 +13,15 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-function load_my_script_for_pmpro_pages() {
+function my_pmpro_load_scripts_example() {
 	global $pmpro_pages;
 
+	// No PMPro pages found, bail
 	if ( empty( $pmpro_pages ) ) {
 		return;
 	}
 
+	// No PMPro function found, bail.
 	if ( ! function_exists( 'pmpro_is_checkout' ) ) {
 		return;
 	}
@@ -30,4 +32,4 @@ function load_my_script_for_pmpro_pages() {
 		<?php
 	}
 }
-add_action( 'wp_head', 'load_my_script_for_pmpro_pages' );
+add_action( 'wp_head', 'my_pmpro_load_scripts_example' );


### PR DESCRIPTION
Migrating snippet to library: https://gist.github.com/andrewlimaza/45c4739734c34666e782d032a1368f3e

Added recipe header.

Added `empty( $pmpro_pages )` check to prevent warnings if PMPro isn't active.

