### PR TITLE
Add: Unlock specific post IDs in a restricted category

### DIFF
--- a/restricting-content/unlock_posts_by_ID.php
+++ b/restricting-content/unlock_posts_by_ID.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * Unlock Specific Post IDs in a Restricted Category
- *
  * This recipe allows specific post IDs to remain publicly accessible even if they are
  * inside a category restricted by Paid Memberships Pro.
  *
@@ -10,22 +8,28 @@
  * collection: restricted-content
  * category: access-control
  * link: https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ * 
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
 
-function unlock_posts_by_ID( $hasaccess, $post, $user, $post_membership_levels ) {
+function my_pmpro_unlock_posts_by_id( $hasaccess, $post, $user, $post_membership_levels ) {
+
 	// If they already have access, let them at it.
 	if ( $hasaccess ) {
 		return $hasaccess;
 	}
 
 	// Set which post IDs are public.
-	$public_post_IDs = array( 1, 2 );
+	$public_post_ids = array( 1, 2 );
 
 	// Now check the post ID.
-	if ( in_array( $post->ID, $public_post_IDs ) ) {
+	if ( in_array( $post->ID, $public_post_ids ) ) {
 		$hasaccess = true;
 	}
 
 	return $hasaccess;
 }
-add_filter( 'pmpro_has_membership_access_filter', 'unlock_posts_by_ID', 15, 4 );
+add_filter( 'pmpro_has_membership_access_filter', 'my_pmpro_unlock_posts_by_id', 15, 4 );

--- a/restricting-content/unlock_posts_by_ID.php
+++ b/restricting-content/unlock_posts_by_ID.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Unlock Specific Post IDs in a Restricted Category
+ *
+ * This recipe allows specific post IDs to remain publicly accessible even if they are
+ * inside a category restricted by Paid Memberships Pro.
+ *
+ * title: Unlock Specific Post IDs in a Restricted Category
+ * layout: snippet
+ * collection: restricted-content
+ * category: access-control
+ * link: https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+function unlock_posts_by_ID( $hasaccess, $post, $user, $post_membership_levels ) {
+	// If they already have access, let them at it.
+	if ( $hasaccess ) {
+		return $hasaccess;
+	}
+
+	// Set which post IDs are public.
+	$public_post_IDs = array( 1, 2 );
+
+	// Now check the post ID.
+	if ( in_array( $post->ID, $public_post_IDs ) ) {
+		$hasaccess = true;
+	}
+
+	return $hasaccess;
+}
+add_filter( 'pmpro_has_membership_access_filter', 'unlock_posts_by_ID', 15, 4 );


### PR DESCRIPTION
### What This Does
Allows specific post IDs to remain publicly accessible even if they are in a category restricted by Paid Memberships Pro.

### Why It's Helpful
Useful when a category is restricted for members-only content, but you want to allow a few specific posts (like announcements or teasers) to stay public.

### Notes
- Update the `$public_post_IDs` array to include the post IDs you want to allow.
- Uses the `pmpro_has_membership_access_filter` filter.