### PR TITLE
Add async Stripe webhook processing for production only in PMPro 3.7+

### DIFF
--- a/payment-gateways/stripe/enable-async-processing-production-only.php
+++ b/payment-gateways/stripe/enable-async-processing-production-only.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Enable async Stripe webhook processing only on the production environment.
+ * Requires PMPro version 3.7+
+ *
+ * title: Enable Async Stripe Webhook Processing Conditionally by Environment
+ * layout: snippet
+ * collection: payment-gateways, stripe
+ * category: action-scheduler
+ * link: tbd
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function mysite_enable_async_stripe_webhooks() {
+    return wp_get_environment_type() === 'production';
+}
+
+add_filter( 'pmpro_stripe_webhook_enable_async_processing', 'mysite_enable_async_stripe_webhooks' );


### PR DESCRIPTION
This snippet enables asynchronous processing of Stripe webhooks only in the production environment, ensuring that it does not affect other environments.