### PR TITLE
Adding recipes for three ways to modify logged email behavior

### DIFF
--- a/email/pmpro-email-log-all-wordpress-emails.php
+++ b/email/pmpro-email-log-all-wordpress-emails.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Log all WordPress emails in the PMPro email log, not just PMPro emails.
+ * By default, PMPro only logs emails it sends itself. This snippet uses
+ * the pmpro_should_log_email filter to capture every outbound email
+ * sent through WordPress.
+ *
+ * Note: Logging all emails increases database size. Monitor your
+ * wp_pmpro_email_logs table over time on high-traffic sites.
+ *
+ * title: Log All WordPress Emails in the PMPro Email Log
+ * layout: snippet
+ * collection: email
+ * category: email-log
+ * link: [add post URL after publish]
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+add_filter( 'pmpro_should_log_email', '__return_true' );

--- a/email/pmpro-email-log-exclude-templates-from-log.php
+++ b/email/pmpro-email-log-exclude-templates-from-log.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Exclude specific PMPro email templates from the email log.
+ * Update the $excluded_templates array with the template names
+ * you want to skip. All other PMPro emails will still be logged.
+ *
+ * title: Exclude Specific PMPro Email Templates From the Email Log
+ * layout: snippet
+ * collection: email
+ * category: email-log
+ * link: [add post URL after publish]
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function my_pmpro_exclude_templates_from_log( $should_log, $email_data ) {
+	// Add or remove template names as needed.
+	$excluded_templates = array(
+		'checkout_paid',
+		'checkout_free',
+	);
+
+	if ( in_array( $email_data['template'], $excluded_templates, true ) ) {
+		return false;
+	}
+
+	return $should_log;
+}
+add_filter( 'pmpro_should_log_email', 'my_pmpro_exclude_templates_from_log', 10, 2 );

--- a/email/pmpro-email-log-specific-recipient.php
+++ b/email/pmpro-email-log-specific-recipient.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Restrict PMPro email logging to a single recipient address.
+ * Only emails sent to the specified address will be recorded in the log.
+ * Useful for auditing or debugging a specific member's communications.
+ *
+ * title: Log Emails for a Specific Recipient in the PMPro Email Log
+ * layout: snippet
+ * collection: email
+ * category: email-log
+ * link: [add post URL after publish]
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function my_pmpro_log_specific_recipient( $should_log, $email_data ) {
+	// Replace with the email address you want to audit.
+	$recipient = 'member@example.com';
+
+	return ( $email_data['email_to'] === $recipient );
+}
+add_filter( 'pmpro_should_log_email', 'my_pmpro_log_specific_recipient', 10, 2 );

--- a/email/pmpro-email-log-specific-recipient.php
+++ b/email/pmpro-email-log-specific-recipient.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Restrict PMPro email logging to a single recipient address.
- * Only emails sent to the specified address will be recorded in the log.
- * Useful for auditing or debugging a specific member's communications.
+ * Restrict PMPro email logging to specific recipient addresses.
+ * Only emails sent to the specified addresses will be recorded in the log.
+ * Useful for auditing or debugging specific members' communications.
  *
- * title: Log Emails for a Specific Recipient in the PMPro Email Log
+ * title: Log Emails for Specific Recipients in the PMPro Email Log
  * layout: snippet
  * collection: email
  * category: email-log
@@ -15,10 +15,14 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-function my_pmpro_log_specific_recipient( $should_log, $email_data ) {
-	// Replace with the email address you want to audit.
-	$recipient = 'member@example.com';
+function my_pmpro_log_specific_recipients( $should_log, $email_data ) {
+	// Add all recipients you want to audit.
+	$recipients = array(
+		'member@example.com',
+		'admin@example.com',
+		'test@example.com',
+	);
 
-	return ( $email_data['email_to'] === $recipient );
+	return in_array( $email_data['email_to'], $recipients, true );
 }
-add_filter( 'pmpro_should_log_email', 'my_pmpro_log_specific_recipient', 10, 2 );
+add_filter( 'pmpro_should_log_email', 'my_pmpro_log_specific_recipients', 10, 2 );


### PR DESCRIPTION
Adds three code recipes for the `pmpro_should_log_email` filter, introduced in PMPro 3.7. These cover the most common use cases for customizing email log behavior:

- **log-all-wordpress-emails.php** — logs every outbound WordPress email, not just PMPro emails (`__return_true`)
- **exclude-templates-from-log.php** — skips logging for a configurable list of PMPro template names
- **log-specific-recipient.php** — restricts logging to a single recipient address, useful for debugging 

All three are documented in the companion blog post (link to be added after publish).