### PR TITLE
Fix generate-username snippet starting PHP sessions globally

### DIFF
--- a/checkout/generate-username-from-email-pmpro.php
+++ b/checkout/generate-username-from-email-pmpro.php
@@ -18,12 +18,20 @@
 
 function my_pmpro_generate_username_at_checkout() {
 
-	// Make sure PMPro is installed and the function to get the level at checkout exists.
-	if ( ! function_exists( 'pmpro_getLevelAtCheckout' ) ) {
+	// Make sure PMPro is installed.
+	if ( ! function_exists( 'pmpro_is_checkout' ) || ! function_exists( 'pmpro_getLevelAtCheckout' ) ) {
 		return;
 	}
 
-	// check for level as well to make sure we're on checkout page
+	// Bail early if not on checkout page.
+	// Note: pmpro_getLevelAtCheckout() triggers discount code filters which can
+	// start PHP sessions (e.g. via the Local Pricing Add On), so we guard with
+	// pmpro_is_checkout() first to avoid starting sessions on every page load.
+	if ( ! pmpro_is_checkout() ) {
+		return;
+	}
+
+	// Check for level to confirm checkout context.
 	if ( empty( pmpro_getLevelAtCheckout() ) ) {
 		return;
 	}
@@ -31,13 +39,13 @@ function my_pmpro_generate_username_at_checkout() {
 	if ( ! empty( $_POST['bemail'] ) ) {
 		$_REQUEST['username'] = $_POST['username'] = my_pmpro_generate_username_from_email( $_POST['bemail'] );
 	}
-	
+
 	if ( ! empty( $_GET['bemail'] ) ) {
 		$_REQUEST['username'] = $_GET['username'] = my_pmpro_generate_username_from_email( $_GET['bemail'] );
 	}
 
 }
-add_action( 'init', 'my_pmpro_generate_username_at_checkout' );
+add_action( 'wp', 'my_pmpro_generate_username_at_checkout', 1 );
 
 /**
  * Hide the username field on checkout.


### PR DESCRIPTION
## Summary

- The `generate-username-from-email-pmpro.php` snippet hooks `init` and calls `pmpro_getLevelAtCheckout()` on every page load
- `pmpro_getLevelAtCheckout()` triggers discount code filters which cascade through Sitewide Sales → Local Pricing → `pmpro_get_session_var()` → `session_start()`
- This starts an empty PHP session on every request, setting a `PHPSESSID` cookie that prevents page caching plugins (Surge, W3TC, etc.) from caching any pages

### Fix

- Add `pmpro_is_checkout()` guard before calling `pmpro_getLevelAtCheckout()` to skip non-checkout pages entirely
- Move hook from `init` to `wp` at priority 1 (before PMPro's checkout preheader at priority 2) so that `pmpro_is_checkout()` has access to `$wp_query`

### Testing

Found and fixed on `www.paidmembershipspro.com` where this snippet was active. Before the fix, Surge reported `x-cache: bypass` on all pages with `PHPSESSID` cookies set on every response. After the fix, non-checkout pages return `x-cache: hit` with no session cookies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)