### PR TITLE
Fix error for visitors without a level on PMPro 3.5+

### DIFF
--- a/integration-compatibility/require-custom-level-group-elementor.php
+++ b/integration-compatibility/require-custom-level-group-elementor.php
@@ -60,11 +60,6 @@ function my_pmpro_elementor_has_membership_level_custom( $has_level, $user_id, $
 		return $has_level;
 	}
 
-	// Bail if our custom level group item is not in the required levels.
-	if ( ! in_array( 'my_pmpro_elementor_custom_levels', $levels ) ) {
-		return $has_level;
-	}
-
 	// Require a membership level from our custom group to view this content.
 	if ( pmpro_hasMembershipLevel( $pmpro_elementor_group_levels ) ) {
 		$has_level = true;

--- a/integration-compatibility/require-custom-level-group-elementor.php
+++ b/integration-compatibility/require-custom-level-group-elementor.php
@@ -60,7 +60,7 @@ function my_pmpro_elementor_has_membership_level_custom( $has_level, $user_id, $
 		return $has_level;
 	}
 
-	// Bail if our custom level group item is not in the required levels.
+	// Bail if $levels is not an array or our custom level group item is not in the required levels.
 	if ( ! is_array( $levels ) || ! in_array( 'my_pmpro_elementor_custom_levels', $levels ) ) {
 		return $has_level;
 	}

--- a/integration-compatibility/require-custom-level-group-elementor.php
+++ b/integration-compatibility/require-custom-level-group-elementor.php
@@ -60,6 +60,11 @@ function my_pmpro_elementor_has_membership_level_custom( $has_level, $user_id, $
 		return $has_level;
 	}
 
+	// Bail if our custom level group item is not in the required levels.
+	if ( ! is_array( $levels ) && ! in_array( 'my_pmpro_elementor_custom_levels', $levels ) ) {
+		return $has_level;
+	}
+
 	// Require a membership level from our custom group to view this content.
 	if ( pmpro_hasMembershipLevel( $pmpro_elementor_group_levels ) ) {
 		$has_level = true;

--- a/integration-compatibility/require-custom-level-group-elementor.php
+++ b/integration-compatibility/require-custom-level-group-elementor.php
@@ -61,7 +61,7 @@ function my_pmpro_elementor_has_membership_level_custom( $has_level, $user_id, $
 	}
 
 	// Bail if our custom level group item is not in the required levels.
-	if ( ! is_array( $levels ) && ! in_array( 'my_pmpro_elementor_custom_levels', $levels ) ) {
+	if ( ! is_array( $levels ) || ! in_array( 'my_pmpro_elementor_custom_levels', $levels ) ) {
 		return $has_level;
 	}
 


### PR DESCRIPTION
Fatal error triggered if a user without a membership level visits a page with Elementor widgets that are restricted for members only.
 
This prevents the fatal error when $levels is null, 0, or a non-array value (which happens when checking for any level or non-members), while preserving the intended behavior: only apply custom logic when Elementor is checking for the specific custom group.