### PR TITLE
Only delete user when fully cancelled (multi-level safe)

### DIFF
--- a/misc/delete-wp-user-when-member-cancels.php
+++ b/misc/delete-wp-user-when-member-cancels.php
@@ -5,8 +5,9 @@
  * Requires PMPro v1.4+
  * Note - Users are not deleted if:
  * (1) They are not cancelling their membership (i.e. $level_id != 0)
- * (2) They are an admin.
- * (3) The level change was initiated from the WP Admin Dashboard
+ * (2) They still have other active membership levels (e.g. levels in other groups).
+ * (3) They are an admin.
+ * (4) The level change was initiated from the WP Admin Dashboard
  * (e.g. when an admin changes a user's level via the edit user's page)
  *
  * title: Delete the WordPress user when a PMPro member cancels
@@ -21,28 +22,37 @@
  */
 
 
-function my_pmpro_after_change_membership_level( $level_id, $user_id ) {
+function my_pmpro_after_change_membership_level( $level_id, $user_id, $cancel_level = null ) {
 
 	// are they cancelling? and don't do this from admin (e.g. when admin's are changing levels)
-	if ( empty( $level_id ) && ! is_admin() ) {
-
-		// only delete non-admins
-		if ( ! user_can( $user_id, 'manage_options' ) ) {
-
-			// remove the delete hooks so we don't try to cancel the membership again
-			remove_action( 'delete_user', 'pmpro_delete_user' );
-			remove_action( 'wpmu_delete_user', 'pmpro_delete_user' );
-
-			// delete the user
-			require_once ABSPATH . '/wp-admin/includes/user.php';
-			wp_delete_user( $user_id );
-
-			// add the delete hooks back in
-			add_action( 'delete_user', 'pmpro_delete_user' );
-			add_action( 'wpmu_delete_user', 'pmpro_delete_user' );
-
-		}
+	if ( ! empty( $level_id ) || is_admin() ) {
+		return;
 	}
 
+	// Only act when we know which level was cancelled (PMPro fires the hook with $cancel_level set on cancellations).
+	if ( empty( $cancel_level ) ) {
+		return;
+	}
+
+	// If the user still has any active membership level (e.g. in another level group), don't delete them.
+	if ( pmpro_hasMembershipLevel( null, $user_id ) ) {
+		return;
+	}
+
+	// only delete non-admins
+	if ( ! user_can( $user_id, 'manage_options' ) ) {
+
+		// remove the delete hooks so we don't try to cancel the membership again
+		remove_action( 'delete_user', 'pmpro_delete_user' );
+		remove_action( 'wpmu_delete_user', 'pmpro_delete_user' );
+
+		// delete the user
+		require_once ABSPATH . '/wp-admin/includes/user.php';
+		wp_delete_user( $user_id );
+
+		// add the delete hooks back in
+		add_action( 'delete_user', 'pmpro_delete_user' );
+		add_action( 'wpmu_delete_user', 'pmpro_delete_user' );
+	}
 }
-add_action( 'pmpro_after_change_membership_level', 'my_pmpro_after_change_membership_level', 10, 2 );
+add_action( 'pmpro_after_change_membership_level', 'my_pmpro_after_change_membership_level', 10, 3 );


### PR DESCRIPTION
## Summary

`misc/delete-wp-user-when-member-cancels.php` deletes the WordPress user any time `pmpro_after_change_membership_level` fires with `$level_id = 0` outside the admin. With Multiple Memberships per User / level groups, cancelling a *single* level in a non-default group fires the same hook with `$level_id = 0` — so cancelling, say, a hosting extra would wipe the entire WP user account even though the member still has other active memberships.

This is a destructive bug (account + WP user data deletion). Any site using this snippet on a multi-level setup is at risk.

## Fix

- Accept the third `$cancel_level` arg from PMPro core (already passed in `paid-memberships-pro/includes/functions.php`).
- Bail when `$cancel_level` is empty (covers the second `do_action` site in core that passes `null`).
- Bail if `pmpro_hasMembershipLevel( null, $user_id )` still returns true — i.e. the user still has another active membership somewhere.
- Bump `add_action` accepted args from 2 → 3.
- Update the docblock note to mention the new guard.

## Test plan

- [ ] User with one membership cancels via the front-end Cancel page → WP user is deleted (existing behavior preserved).
- [ ] User with two levels in separate groups cancels just one → WP user is **not** deleted, other membership remains.
- [ ] Admin changes a user's level via Users → Edit User → WP user is **not** deleted.
- [ ] Admin user with `manage_options` cancels → not deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)