### PR TITLE
Respect $cancel_level + remaining levels in cancel/expiration handler

### DIFF
--- a/membership-levels/change-membership-level-on-cancellation-expiration.php
+++ b/membership-levels/change-membership-level-on-cancellation-expiration.php
@@ -16,12 +16,19 @@
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
 
-function pmpro_after_change_membership_level_default_level( $level_id, $user_id ) {
+function pmpro_after_change_membership_level_default_level( $level_id, $user_id, $cancel_level = null ) {
 
-	if ( $level_id == 0 ) {
-		// cancelling, give them level 1 instead
-		pmpro_changeMembershipLevel( 1, $user_id );
+	// Only act on cancellations (level_id 0) and only when we know which level was cancelled.
+	if ( $level_id != 0 || empty( $cancel_level ) ) {
+		return;
 	}
 
+	// If the user still has another active membership level (e.g. in another level group), don't downgrade them.
+	if ( pmpro_hasMembershipLevel( null, $user_id ) ) {
+		return;
+	}
+
+	// cancelling, give them level 1 instead
+	pmpro_changeMembershipLevel( 1, $user_id );
 }
-add_action( 'pmpro_after_change_membership_level', 'pmpro_after_change_membership_level_default_level', 10, 2 );
+add_action( 'pmpro_after_change_membership_level', 'pmpro_after_change_membership_level_default_level', 10, 3 );


### PR DESCRIPTION
## Summary

`membership-levels/change-membership-level-on-cancellation-expiration.php` force-changes a member to level 1 any time `pmpro_after_change_membership_level` fires with `$level_id = 0`. With Multiple Memberships per User / level groups, cancelling a single level in a non-default group fires the same hook — so the user gets dropped to level 1 even though they still have other active memberships.

## Fix

- Accept the third `$cancel_level` arg PMPro core already passes.
- Bail when `$cancel_level` is empty (covers the `do_action` site that passes `null`).
- Bail when `pmpro_hasMembershipLevel( null, $user_id )` still returns true — only downgrade users who have no active levels left.
- Bump `add_action` accepted args from 2 → 3.

## Test plan

- [ ] User cancels their only membership → ends up on level 1 (existing behavior preserved).
- [ ] User with two levels in separate groups cancels one → keeps the remaining level, no level 1 forced.
- [ ] Membership expires (PMPro cron) → ends up on level 1 (this hook fires for expirations too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)