### PR TITLE
Respect $cancel_level in allow-default-cancel handler

### DIFF
--- a/membership-levels/change-membership-level-on-cancellation-expiration-allow-default-cancel.php
+++ b/membership-levels/change-membership-level-on-cancellation-expiration-allow-default-cancel.php
@@ -15,7 +15,7 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-function my_pmpro_after_change_membership_level_default_level( $level_id, $user_id ) {
+function my_pmpro_after_change_membership_level_default_level( $level_id, $user_id, $cancel_level = null ) {
 	// set this to the id of the level you want to give members when they cancel
 	$cancel_level_id = 1;
 
@@ -25,17 +25,22 @@ function my_pmpro_after_change_membership_level_default_level( $level_id, $user_
 		return;
 	}
 
-	// are they cancelling?
-	if ( $level_id == 0 ) {
-		// check if they are cancelling from level $cancel_level_id
-		global $wpdb;
-		$last_level_id = $wpdb->get_var( "SELECT membership_id FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user_id . "' ORDER BY id DESC" );
-		if ( $last_level_id == $cancel_level_id ) {
-			return; // let them cancel
-		}
-
-		// otherwise give them level $cancel_level_id instead
-		pmpro_changeMembershipLevel( $cancel_level_id, $user_id );
+	// Only act on cancellations (level_id 0) and only when we know which level was cancelled.
+	if ( $level_id != 0 || empty( $cancel_level ) ) {
+		return;
 	}
+
+	// If they are cancelling from the cancel level itself, let them cancel for real.
+	if ( $cancel_level == $cancel_level_id ) {
+		return;
+	}
+
+	// If the user still has another active membership level (e.g. in another level group), don't downgrade them.
+	if ( pmpro_hasMembershipLevel( null, $user_id ) ) {
+		return;
+	}
+
+	// otherwise give them level $cancel_level_id instead
+	pmpro_changeMembershipLevel( $cancel_level_id, $user_id );
 }
-add_action( 'pmpro_after_change_membership_level', 'my_pmpro_after_change_membership_level_default_level', 10, 2 );
+add_action( 'pmpro_after_change_membership_level', 'my_pmpro_after_change_membership_level_default_level', 10, 3 );


### PR DESCRIPTION
## Summary

`membership-levels/change-membership-level-on-cancellation-expiration-allow-default-cancel.php` used a SQL "last membership row" query to figure out which level was being cancelled. With Multiple Memberships per User / level groups, that query frequently returns a level in another group — so cancelling a separate-group level (e.g. a hosting extra) downgraded the user's main level.

This is the same bug class as #443 and #444; this snippet matches the variant we hit in production (the one we just patched in `pmpro-site-customizations`).

## Fix

- Accept the third `$cancel_level` arg PMPro core already passes.
- Compare `$cancel_level` to `$cancel_level_id` directly instead of guessing via SQL.
- Bail when `pmpro_hasMembershipLevel( null, $user_id )` still returns true (multi-level safety).
- Drop the SQL fallback entirely.
- Bump `add_action` accepted args from 2 → 3.

## Test plan

- [ ] User cancels their only membership → ends up on `$cancel_level_id` (existing behavior preserved).
- [ ] User cancels from `$cancel_level_id` itself → cancellation goes through (existing behavior preserved).
- [ ] User with two levels in separate groups cancels one → keeps the remaining level, no forced downgrade.
- [ ] Confirm `$pmpro_next_payment_timestamp` short-circuit still bails (cancel-on-next-payment-date flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)