### PR TITLE
Add level-specific option to cancel-membership-level-immediately snippet

### DIFF
--- a/membership-levels/cancel-membership-level-immediately.php
+++ b/membership-levels/cancel-membership-level-immediately.php
@@ -2,9 +2,6 @@
 /**
  * Cancel an automatically recurring payment membership level immediately.
  *
- * By default this applies to all membership levels. To restrict cancellation
- * to specific levels only, see the level-specific example at the bottom of this file.
- *
  * title: Cancel Recurring Level Immediately
  * layout: snippet
  * collection: membership-levels
@@ -16,24 +13,4 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-
-// Option 1: Cancel immediately for ALL membership levels.
 add_filter( 'pmpro_cancel_on_next_payment_date', '__return_false' );
-
-/**
- * Option 2: Cancel immediately for specific membership levels only.
- *
- * Replace the level IDs in the array below with the levels you want
- * to cancel immediately. All other levels retain the default behavior.
- */
-// function my_pmpro_cancel_specific_levels_immediately( $cancel ) {
-// 	// Add the membership level IDs that should cancel immediately.
-// 	$cancel_immediately_levels = array( 1, 2 );
-//
-// 	if ( pmpro_hasMembershipLevel( $cancel_immediately_levels, get_current_user_id() ) ) {
-// 		return false;
-// 	}
-//
-// 	return $cancel;
-// }
-// add_filter( 'pmpro_cancel_on_next_payment_date', 'my_pmpro_cancel_specific_levels_immediately' );

--- a/membership-levels/cancel-membership-level-immediately.php
+++ b/membership-levels/cancel-membership-level-immediately.php
@@ -2,6 +2,9 @@
 /**
  * Cancel an automatically recurring payment membership level immediately.
  *
+ * By default this applies to all membership levels. To restrict cancellation
+ * to specific levels only, see the level-specific example at the bottom of this file.
+ *
  * title: Cancel Recurring Level Immediately
  * layout: snippet
  * collection: membership-levels
@@ -13,4 +16,24 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
+
+// Option 1: Cancel immediately for ALL membership levels.
 add_filter( 'pmpro_cancel_on_next_payment_date', '__return_false' );
+
+/**
+ * Option 2: Cancel immediately for specific membership levels only.
+ *
+ * Replace the level IDs in the array below with the levels you want
+ * to cancel immediately. All other levels retain the default behavior.
+ */
+// function my_pmpro_cancel_specific_levels_immediately( $cancel ) {
+// 	// Add the membership level IDs that should cancel immediately.
+// 	$cancel_immediately_levels = array( 1, 2 );
+//
+// 	if ( pmpro_hasMembershipLevel( $cancel_immediately_levels, get_current_user_id() ) ) {
+// 		return false;
+// 	}
+//
+// 	return $cancel;
+// }
+// add_filter( 'pmpro_cancel_on_next_payment_date', 'my_pmpro_cancel_specific_levels_immediately' );

--- a/membership-levels/cancel-specific-membership-levels-immediately.php
+++ b/membership-levels/cancel-specific-membership-levels-immediately.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Cancel specific levels immediately instead of extending until the end of the billing cycle.
+ *
+ * title: Cancel Specific Recurring Levels Immediately
+ * layout: snippet
+ * collection: membership-levels
+ * category: cancellation
+ * link: https://www.paidmembershipspro.com/documentation/membership-levels/canceling-a-user-membership/
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * Cancel immediately for specific membership levels only.
+ *
+ * Replace the level IDs in the array below with the levels you want
+ * to cancel immediately. All other levels retain the default behavior.
+ */
+function my_pmpro_cancel_specific_levels_immediately( $cancel ) {
+	// Update this array with the level IDs you want to cancel immediately.
+	$cancel_immediately_levels = array( 1, 2 );
+
+	if ( pmpro_hasMembershipLevel( $cancel_immediately_levels, get_current_user_id() ) ) {
+		return false;
+	}
+
+	return $cancel;
+}
+add_filter( 'pmpro_cancel_on_next_payment_date', 'my_pmpro_cancel_specific_levels_immediately' );


### PR DESCRIPTION
## Summary

- Keeps the existing one-liner (`__return_false`) as **Option 1** for cancelling all levels immediately
- Adds a commented-out **Option 2** showing how to target specific membership level IDs using `pmpro_hasMembershipLevel()`
- Users can uncomment Option 2 and replace the level IDs array to suit their setup

## Test plan
- [ ] Verify Option 1 (all levels) still works as before
- [ ] Uncomment Option 2, assign level IDs, confirm only those levels cancel immediately
- [ ] Confirm other levels retain default (cancel on next payment date) behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)