### PR TITLE
Adding snippet for a coming soon redirect as well as snippets for hardening built off our internal team WP site's logic

### DIFF
--- a/misc/block-author-enumeration.php
+++ b/misc/block-author-enumeration.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Block author enumeration via ?author=N requests.
+ *
+ * title: Block author enumeration to hide usernames
+ * layout: snippet
+ * collection: misc
+ * category: security, login
+ * link: TBD
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * By default, WordPress will resolve a URL like /?author=1 to the author's
+ * archive, which exposes the user's login slug in the redirect URL. This
+ * snippet redirects those requests to the home page for logged-out users
+ * before WordPress resolves the slug.
+ */
+function my_block_author_enumeration() {
+	if ( ! is_user_logged_in() && isset( $_GET['author'] ) ) {
+		wp_safe_redirect( home_url() );
+		exit;
+	}
+}
+add_action( 'init', 'my_block_author_enumeration' );

--- a/misc/block-author-enumeration.php
+++ b/misc/block-author-enumeration.php
@@ -17,11 +17,15 @@
 /**
  * By default, WordPress will resolve a URL like /?author=1 to the author's
  * archive, which exposes the user's login slug in the redirect URL. This
- * snippet redirects those requests to the home page for logged-out users
- * before WordPress resolves the slug.
+ * snippet redirects those requests to the home page for anyone without
+ * the edit_posts capability — so admins, editors, and authors can still
+ * view author archives while subscribers and logged-out visitors can't.
+ *
+ * If you want author enumeration available to all logged-in users (subscribers
+ * included), swap ! current_user_can( 'edit_posts' ) for ! is_user_logged_in().
  */
 function my_block_author_enumeration() {
-	if ( ! is_user_logged_in() && isset( $_GET['author'] ) ) {
+	if ( ! current_user_can( 'edit_posts' ) && isset( $_GET['author'] ) ) {
 		wp_safe_redirect( home_url() );
 		exit;
 	}

--- a/misc/block-rest-api-users-endpoint.php
+++ b/misc/block-rest-api-users-endpoint.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Block the REST API users endpoint for non-admins.
+ *
+ * title: Block the REST API users endpoint to hide usernames
+ * layout: snippet
+ * collection: misc
+ * category: security, login
+ * link: TBD
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * By default, GET /wp-json/wp/v2/users returns every user who has authored
+ * a published post — login slug, display name, and avatar URL. This snippet
+ * blocks the /wp/v2/users route (and the single-user /wp/v2/users/<id> variant)
+ * for anyone without the list_users capability, while leaving the rest of
+ * the REST API untouched so the block editor, search, forms, and other
+ * plugins keep working.
+ */
+function my_block_rest_api_users_endpoint( $result, $server, $request ) {
+	// If another callback already returned a response, respect it.
+	if ( null !== $result ) {
+		return $result;
+	}
+
+	// Allow users who are normally permitted to list users (admins, etc.).
+	if ( current_user_can( 'list_users' ) ) {
+		return $result;
+	}
+
+	// Block /wp/v2/users and /wp/v2/users/<id>.
+	if ( strpos( $request->get_route(), '/wp/v2/users' ) === 0 ) {
+		return new WP_Error(
+			'rest_user_cannot_view',
+			'Sorry, you are not allowed to list users.',
+			array( 'status' => 401 )
+		);
+	}
+
+	return $result;
+}
+add_filter( 'rest_pre_dispatch', 'my_block_rest_api_users_endpoint', 10, 3 );

--- a/misc/block-rest-api-users-endpoint.php
+++ b/misc/block-rest-api-users-endpoint.php
@@ -34,11 +34,13 @@ function my_block_rest_api_users_endpoint( $result, $server, $request ) {
 	}
 
 	// Block /wp/v2/users and /wp/v2/users/<id>.
+	// 403 (Forbidden) is the right status here: logged-in non-admins hit this
+	// path too, and 401 would incorrectly suggest authentication would help.
 	if ( strpos( $request->get_route(), '/wp/v2/users' ) === 0 ) {
 		return new WP_Error(
 			'rest_user_cannot_view',
 			'Sorry, you are not allowed to list users.',
-			array( 'status' => 401 )
+			array( 'status' => 403 )
 		);
 	}
 

--- a/misc/disable-user-sitemap.php
+++ b/misc/disable-user-sitemap.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Disable the WordPress user sitemap so usernames aren't exposed.
+ *
+ * title: Disable the user sitemap to hide usernames
+ * layout: snippet
+ * collection: misc
+ * category: security
+ * link: TBD
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/*
+ * Unregister the entire 'users' sitemap provider, so no user sitemap pages
+ * are generated. Other providers (posts, pages, taxonomies) are unaffected.
+ */
+function my_disable_user_sitemap( $provider, $name ) {
+	if ( 'users' === $name ) {
+		return false;
+	}
+	return $provider;
+}
+add_filter( 'wp_sitemaps_add_provider', 'my_disable_user_sitemap', 10, 2 );

--- a/misc/rate-limit-password-resets.php
+++ b/misc/rate-limit-password-resets.php
@@ -26,6 +26,8 @@ function my_rate_limit_password_resets( $errors ) {
 	 *
 	 * Only trust these headers when you actually have a proxy in front of the
 	 * site; on a direct-hit site they can be spoofed by the client.
+	 * 
+	 * If you are using the latest version of PMPro, you may use `pmpro_get_ip()` instead, which handles proxy headers for you.
 	 */
 	$ip    = $_SERVER['REMOTE_ADDR'];
 	$key   = 'my_pwreset_' . md5( $ip );

--- a/misc/rate-limit-password-resets.php
+++ b/misc/rate-limit-password-resets.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Rate limit password reset requests by IP address.
+ *
+ * title: Rate limit password reset requests
+ * layout: snippet
+ * collection: misc
+ * category: security, login
+ * link: TBD
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function my_rate_limit_password_resets( $errors ) {
+	$ip    = $_SERVER['REMOTE_ADDR'];
+	$key   = 'my_pwreset_' . md5( $ip );
+	$count = (int) get_transient( $key );
+
+	/**
+	 * Cap password reset requests at 3 per IP address per hour. This helps
+	 * slow down automated abuse of the lost-password form without affecting
+	 * legitimate users who occasionally need a reset.
+	 *
+	 * Adjust the limit or window by changing the 3 and HOUR_IN_SECONDS values below.
+	 */
+	if ( $count >= 3 ) {
+		$errors->add( 'too_many_requests', 'Too many password reset requests. Please try again later.' );
+		return;
+	}
+
+	set_transient( $key, $count + 1, HOUR_IN_SECONDS );
+}
+add_action( 'lostpassword_post', 'my_rate_limit_password_resets' );

--- a/misc/rate-limit-password-resets.php
+++ b/misc/rate-limit-password-resets.php
@@ -14,6 +14,19 @@
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
 function my_rate_limit_password_resets( $errors ) {
+	/**
+	 * Identify the visitor by IP. REMOTE_ADDR is correct when WordPress is
+	 * reached directly. If your site sits behind Cloudflare or another reverse
+	 * proxy, REMOTE_ADDR will be the proxy's IP and every visitor will share a
+	 * single rate-limit bucket — three failed resets will block resets site-wide
+	 * for an hour. In that case swap in the appropriate forwarded-IP header:
+	 *
+	 *   Cloudflare:    $_SERVER['HTTP_CF_CONNECTING_IP']
+	 *   Generic proxy: $_SERVER['HTTP_X_FORWARDED_FOR'] (validate and take the first IP)
+	 *
+	 * Only trust these headers when you actually have a proxy in front of the
+	 * site; on a direct-hit site they can be spoofed by the client.
+	 */
 	$ip    = $_SERVER['REMOTE_ADDR'];
 	$key   = 'my_pwreset_' . md5( $ip );
 	$count = (int) get_transient( $key );
@@ -24,6 +37,11 @@ function my_rate_limit_password_resets( $errors ) {
 	 * legitimate users who occasionally need a reset.
 	 *
 	 * Adjust the limit or window by changing the 3 and HOUR_IN_SECONDS values below.
+	 *
+	 * Note: this is best-effort throttling. Two concurrent requests can both read
+	 * the same transient value before either writes, letting a few extra attempts
+	 * through under load. For hard enforcement, pair this with server-level rate
+	 * limiting (Nginx limit_req, Cloudflare rate rules, etc.).
 	 */
 	if ( $count >= 3 ) {
 		$errors->add( 'too_many_requests', 'Too many password reset requests. Please try again later.' );

--- a/restricting-content/redirect-non-admins-to-coming-soon-page.php
+++ b/restricting-content/redirect-non-admins-to-coming-soon-page.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Redirect non-admin users to a Coming Soon page.
+ *
+ * title: Redirect non-admin users to a Coming Soon page
+ * layout: snippet
+ * collection: restricting-content
+ * category: content, restriction, redirects
+ * link: TBD
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function my_coming_soon_redirect() {
+	// Set this to your Coming Soon page's ID.
+	$coming_soon_page_id = 123;
+
+	// Bail if the Coming Soon page doesn't exist or isn't published.
+	// This prevents a redirect loop and keeps the site accessible if the ID is wrong.
+	if ( 'publish' !== get_post_status( $coming_soon_page_id ) ) {
+		return;
+	}
+
+	// If we're already on the Coming Soon page, do nothing.
+	if ( is_page( $coming_soon_page_id ) ) {
+		return;
+	}
+
+	// Let admins through (they're building the site).
+	if ( current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	// Allow the login and admin pages so admins can log in.
+	if ( strpos( $_SERVER['REQUEST_URI'], 'wp-login' ) !== false
+		|| strpos( $_SERVER['REQUEST_URI'], 'wp-admin' ) !== false ) {
+		return;
+	}
+
+	// Everyone else gets the Coming Soon page.
+	wp_safe_redirect( get_permalink( $coming_soon_page_id ) );
+	exit;
+}
+add_action( 'template_redirect', 'my_coming_soon_redirect' );

--- a/restricting-content/redirect-non-admins-to-coming-soon-page.php
+++ b/restricting-content/redirect-non-admins-to-coming-soon-page.php
@@ -34,8 +34,9 @@ function my_coming_soon_redirect() {
 	}
 
 	// Allow the login and admin pages so admins can log in.
-	if ( strpos( $_SERVER['REQUEST_URI'], 'wp-login' ) !== false
-		|| strpos( $_SERVER['REQUEST_URI'], 'wp-admin' ) !== false ) {
+	// Match the path prefix exactly so a URL like /wp-administrators/ doesn't slip through.
+	if ( strpos( $_SERVER['REQUEST_URI'], '/wp-admin/' ) === 0
+		|| strpos( $_SERVER['REQUEST_URI'], '/wp-login.php' ) === 0 ) {
 		return;
 	}
 


### PR DESCRIPTION
Snippet for a coming soon page redirect for non-admins.

Plus, four snippets for hardening WordPress, focused on four user-leak areas for

- /?author=N redirect
- /wp-sitemap-users-1.xml
- /wp-json/wp/v2/users
- Login error messages

Plus misc/rate-limit-password-resets.php for brute-force mitigation. That's a clean set for the hardening post to anchor around.
