### PR TITLE
Update show-content-to-paying-non-paying-members.php

### DIFF
--- a/restricting-content/show-content-to-paying-non-paying-members.php
+++ b/restricting-content/show-content-to-paying-non-paying-members.php
@@ -25,37 +25,37 @@
 function my_hasPaid( $user_id = null, $level_id = null ) {
 	global $wpdb;
 
-	// Make sure PMPro is active
+	// Make sure PMPro is active.
 	if ( ! function_exists( 'pmpro_getOption' ) ) {
 		return false;
 	}
 
-	// No user passed? Default to the current user
+	// No user passed? Default to the current user.
 	if ( empty( $user_id ) ) {
 		$user_id = get_current_user_id();
 	}
-	
+
 	// No user?
 	if ( empty( $user_id ) ) {
 		return false;
 	}
-	
-	// Figure out if we are in a live or test gateway environment
+
+	// Figure out if we are in a live or test gateway environment.
 	$environment = pmpro_getOption( 'gateway_environment' );
-	
-	// Query to check
+
+	// Query to check.
 	$sql  = "SELECT COUNT(*) FROM $wpdb->pmpro_membership_orders WHERE user_id = %d AND gateway_environment = %s AND total > 0 AND status NOT IN('error', 'refunded', 'token', 'review')";
 	$args = array( $user_id, $environment );
 
 	if ( ! empty( $level_id ) ) {
-		$sql   .= " AND membership_id = %d";
+		$sql   .= ' AND membership_id = %d';
 		$args[] = $level_id;
 	}
 
-	// Get val
+	// Get val.
 	$paid = $wpdb->get_var( $wpdb->prepare( $sql, $args ) );
-	
-	// Force true/false
+
+	// Force true/false.
 	return (bool) $paid;
 }
 
@@ -73,36 +73,37 @@ function my_hasPaid( $user_id = null, $level_id = null ) {
  * @param  string      $code    The shortcode tag. Unused.
  * @return string      Rendered content, or an empty string when the condition is not met.
  */
-function my_haspaid_shortcode( $atts, $content = null, $code = "" ) {
-	$atts = shortcode_atts( array(
-		'paid'  => true,
-		'level' => null,
-	), $atts );
+function my_haspaid_shortcode( $atts, $content = null, $code = '' ) {
+	$atts  = shortcode_atts(
+		array(
+			'paid'  => true,
+			'level' => null,
+		),
+		$atts
+	);
 	$paid  = $atts['paid'];
 	$level = $atts['level'];
-		
-	// Convert paid attribute to bool
-	if ( $paid === '0' || $paid === 'false' ) {
+
+	// Convert paid attribute to bool.
+	if ( '0' === $paid || 'false' === $paid ) {
 		$paid = false;
 	} else {
 		$paid = true;
 	}
-	
-	// To show or not to show
+
+	// To show or not to show.
 	if ( my_hasPaid( null, $level ) ) {
-		// Return content if paid
+		// Return content if paid.
 		if ( $paid ) {
-			return do_shortcode( $content );	// show content
+			return do_shortcode( $content ); // show content.
 		} else {
 			return '';
 		}
+	} elseif ( ! $paid ) {
+		// Return content if NOT paid.
+		return do_shortcode( $content ); // show content.
 	} else {
-		// Return content if NOT paid
-		if ( ! $paid ) {
-			return do_shortcode( $content );	// show content
-		} else {
-			return "";	// just hide it
-		}
+		return ''; // just hide it.
 	}
 }
 add_shortcode( 'haspaid', 'my_haspaid_shortcode' );

--- a/restricting-content/show-content-to-paying-non-paying-members.php
+++ b/restricting-content/show-content-to-paying-non-paying-members.php
@@ -61,10 +61,12 @@ function my_haspaid_shortcode( $atts, $content = null, $code = "" ) {
 	// $content ::= text within enclosing form of shortcode element
 	// $code    ::= the shortcode found, when == callback name
 	// examples: [haspaid level="3"]...[/haspaid]
-	extract( shortcode_atts( array(
+	$atts = shortcode_atts( array(
 		'paid'  => true,
 		'level' => null,
-	), $atts ) );
+	), $atts );
+	$paid  = $atts['paid'];
+	$level = $atts['level'];
 		
 	// Convert paid attribute to bool
 	if ( $paid === '0' || $paid === 'false' ) {

--- a/restricting-content/show-content-to-paying-non-paying-members.php
+++ b/restricting-content/show-content-to-paying-non-paying-members.php
@@ -81,7 +81,7 @@ function my_haspaid_shortcode( $atts, $content = null, $code = "" ) {
 		if ( $paid ) {
 			return do_shortcode( $content );	// show content
 		} else {
-			return false;
+			return '';
 		}
 	} else {
 		// Return content if NOT paid

--- a/restricting-content/show-content-to-paying-non-paying-members.php
+++ b/restricting-content/show-content-to-paying-non-paying-members.php
@@ -75,10 +75,8 @@ function my_haspaid_shortcode( $atts, $content = null, $code = "" ) {
 		$paid = true;
 	}
 	
-	global $current_user;
-	
 	// To show or not to show
-	if ( my_hasPaid( $current_user->ID, $level ) ) {
+	if ( my_hasPaid( null, $level ) ) {
 		// Return content if paid
 		if ( $paid ) {
 			return do_shortcode( $content );	// show content

--- a/restricting-content/show-content-to-paying-non-paying-members.php
+++ b/restricting-content/show-content-to-paying-non-paying-members.php
@@ -26,7 +26,7 @@ function my_hasPaid( $user_id = null, $level_id = null ) {
 	global $wpdb;
 
 	// Make sure PMPro is active.
-	if ( ! function_exists( 'pmpro_getOption' ) ) {
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
 		return false;
 	}
 
@@ -35,13 +35,13 @@ function my_hasPaid( $user_id = null, $level_id = null ) {
 		$user_id = get_current_user_id();
 	}
 
-	// No user?
+	// Still no user?
 	if ( empty( $user_id ) ) {
 		return false;
 	}
 
 	// Figure out if we are in a live or test gateway environment.
-	$environment = pmpro_getOption( 'gateway_environment' );
+	$environment = get_option( 'pmpro_gateway_environment' );
 
 	// Query to check.
 	$sql  = "SELECT COUNT(*) FROM $wpdb->pmpro_membership_orders WHERE user_id = %d AND gateway_environment = %s AND total > 0 AND status NOT IN('error', 'refunded', 'token', 'review')";

--- a/restricting-content/show-content-to-paying-non-paying-members.php
+++ b/restricting-content/show-content-to-paying-non-paying-members.php
@@ -16,16 +16,16 @@
  */
 // Check if a user ever paid
 function my_hasPaid( $user_id = null, $level_id = null ) {
-	global $current_user, $wpdb;
-	
+	global $wpdb;
+
 	// Make sure PMPro is active
 	if ( ! function_exists( 'pmpro_getOption' ) ) {
 		return false;
 	}
-	
+
 	// No user passed? Default to the current user
 	if ( empty( $user_id ) ) {
-		$user_id = $current_user->ID;
+		$user_id = get_current_user_id();
 	}
 	
 	// No user?

--- a/restricting-content/show-content-to-paying-non-paying-members.php
+++ b/restricting-content/show-content-to-paying-non-paying-members.php
@@ -37,7 +37,7 @@ function my_hasPaid( $user_id = null, $level_id = null ) {
 	$environment = pmpro_getOption( 'gateway_environment' );
 	
 	// Query to check
-	$sql  = "SELECT COUNT(*) FROM $wpdb->pmpro_membership_orders WHERE user_id = %d AND gateway_environment = %s AND total > 0 AND status NOT IN('error', 'refund', 'token', 'review')";
+	$sql  = "SELECT COUNT(*) FROM $wpdb->pmpro_membership_orders WHERE user_id = %d AND gateway_environment = %s AND total > 0 AND status NOT IN('error', 'refunded', 'token', 'review')";
 	$args = array( $user_id, $environment );
 
 	if ( ! empty( $level_id ) ) {

--- a/restricting-content/show-content-to-paying-non-paying-members.php
+++ b/restricting-content/show-content-to-paying-non-paying-members.php
@@ -37,13 +37,16 @@ function my_hasPaid( $user_id = null, $level_id = null ) {
 	$environment = pmpro_getOption( 'gateway_environment' );
 	
 	// Query to check
-	$sqlQuery = "SELECT COUNT(*) FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . esc_sql( $user_id ) . "' AND gateway_environment = '" . esc_sql( $environment ) . "' AND total > 0 AND status NOT IN('error', 'refund', 'token', 'review') ";
+	$sql  = "SELECT COUNT(*) FROM $wpdb->pmpro_membership_orders WHERE user_id = %d AND gateway_environment = %s AND total > 0 AND status NOT IN('error', 'refund', 'token', 'review')";
+	$args = array( $user_id, $environment );
+
 	if ( ! empty( $level_id ) ) {
-		$sqlQuery .= "AND membership_id = '" . esc_sql( $level_id ) . "' LIMIT 1";
+		$sql   .= " AND membership_id = %d";
+		$args[] = $level_id;
 	}
-		
+
 	// Get val
-	$paid = $wpdb->get_var( $sqlQuery );
+	$paid = $wpdb->get_var( $wpdb->prepare( $sql, $args ) );
 	
 	// Force true/false
 	return (bool) $paid;

--- a/restricting-content/show-content-to-paying-non-paying-members.php
+++ b/restricting-content/show-content-to-paying-non-paying-members.php
@@ -19,7 +19,7 @@ function my_hasPaid( $user_id = null, $level_id = null ) {
 	global $current_user, $wpdb;
 	
 	// Make sure PMPro is active
-	if ( ! isset( $wpdb->pmpro_membership_orders ) ) {
+	if ( ! function_exists( 'pmpro_getOption' ) ) {
 		return false;
 	}
 	

--- a/restricting-content/show-content-to-paying-non-paying-members.php
+++ b/restricting-content/show-content-to-paying-non-paying-members.php
@@ -14,7 +14,14 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-// Check if a user ever paid
+
+/**
+ * Check whether a user has any successful paid PMPro order.
+ *
+ * @param  int|null $user_id  WordPress user ID. Defaults to the current user when null/empty.
+ * @param  int|null $level_id Optional PMPro membership level ID to restrict the check to.
+ * @return bool     True if the user has at least one matching paid order, false otherwise.
+ */
 function my_hasPaid( $user_id = null, $level_id = null ) {
 	global $wpdb;
 
@@ -52,18 +59,21 @@ function my_hasPaid( $user_id = null, $level_id = null ) {
 	return (bool) $paid;
 }
 
-/*
-	Shortcode attributes using the my_hasPaid function.
-	[haspaid]This will show up if the user has paid for any level.[/haspaid]
-	[haspaid paid='0']This will show up if the user has NOT paid for any level.[/haspaid]
-	[haspaid paid='1' level='1']This will show up if the user has paid for level 1 specifically.[/haspaid]
-	[haspaid paid='0' level='1']This will show up if the user has not paid for level 1 specifically.[/haspaid]
-*/
+/**
+ * Add [haspaid] shortcode to conditionally render content based on the user's payment history.
+ *
+ * Examples:
+ * [haspaid]This will show up if the user has paid for any level.[/haspaid]
+ * [haspaid paid='0']This will show up if the user has NOT paid for any level.[/haspaid]
+ * [haspaid paid='1' level='1']This will show up if the user has paid for level 1 specifically.[/haspaid]
+ * [haspaid paid='0' level='1']This will show up if the user has not paid for level 1 specifically.[/haspaid]
+ *
+ * @param  array       $atts    Shortcode attributes: 'paid' (true by default; '0'/'false' inverts) and 'level' (PMPro level ID, optional).
+ * @param  string|null $content Enclosed shortcode content to render conditionally.
+ * @param  string      $code    The shortcode tag. Unused.
+ * @return string      Rendered content, or an empty string when the condition is not met.
+ */
 function my_haspaid_shortcode( $atts, $content = null, $code = "" ) {
-	// $atts    ::= array of attributes
-	// $content ::= text within enclosing form of shortcode element
-	// $code    ::= the shortcode found, when == callback name
-	// examples: [haspaid level="3"]...[/haspaid]
 	$atts = shortcode_atts( array(
 		'paid'  => true,
 		'level' => null,


### PR DESCRIPTION
Mostly WPCS related changes. Functionality unchanged.

Using function_exists() to check if PMPro is active in my_hasPaid.

Fixes order status typo 'refund' to 'refunded' in my_hasPaid.

Using wpdb->prepare() for my_hasPaid SQL query.

Updated docblocks.