### PR TITLE
Create send-daily-members-list-csv-export-email.php

### DIFF
--- a/email/send-daily-members-list-csv-export-email.php
+++ b/email/send-daily-members-list-csv-export-email.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Daily CSV Export Emailer for PMPro Members by Level
+ *
+ * Hooks into PMPro's built-in Action Scheduler (pmpro_schedule_daily) to
+ * generate a CSV export per membership level and email it to the site admin.
+ *
+ * Configure the level IDs and recipient email below.
+ *
+ * @link https://www.paidmembershipspro.com/
+ */
+
+// Level IDs to export. Replace 1 and 2 with real level IDs.
+define( 'MY_CSV_LEVEL_ID_1', 1 );
+define( 'MY_CSV_LEVEL_ID_2', 2 );
+
+// Email recipient. Defaults to site admin email.
+define( 'MY_CSV_EMAIL_TO', get_option( 'admin_email' ) );
+
+/**
+ * Hook into PMPro's Action Scheduler daily event.
+ * PMPro registers and fires this automatically - no cron setup needed.
+ */
+add_action( 'pmpro_schedule_daily', 'my_pmpro_daily_csv_emailer' );
+
+/**
+ * Generate and email CSVs for each configured membership level.
+ *
+ * @return void
+ */
+function my_pmpro_daily_csv_emailer() {
+	$level_ids = array( MY_CSV_LEVEL_ID_1, MY_CSV_LEVEL_ID_2 );
+
+	foreach ( $level_ids as $level_id ) {
+		my_pmpro_generate_and_email_csv( $level_id, MY_CSV_EMAIL_TO );
+	}
+}
+
+/**
+ * Generate a members CSV for a given level and email it as an attachment.
+ *
+ * @param int    $level_id  The membership level ID to export.
+ * @param string $email_to  The recipient email address.
+ * @return void
+ */
+function my_pmpro_generate_and_email_csv( $level_id, $email_to ) {
+	global $wpdb;
+
+	// Validate the level exists.
+	$level = pmpro_getLevel( $level_id );
+	if ( empty( $level ) ) {
+		return;
+	}
+
+	// Get active members for this level.
+	$members = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT u.ID, u.user_login, u.user_email, u.user_registered, mu.startdate, mu.enddate
+			 FROM {$wpdb->users} u
+			 INNER JOIN {$wpdb->pmpro_memberships_users} mu ON u.ID = mu.user_id
+			 WHERE mu.membership_id = %d
+			   AND mu.status = 'active'
+			 ORDER BY u.user_registered ASC",
+			$level_id
+		)
+	);
+
+	if ( empty( $members ) ) {
+		return;
+	}
+
+	// Build the date format used across PMPro member exports.
+	$date_format = apply_filters( 'pmpro_memberslist_csv_dateformat', 'Y-m-d' );
+
+	// Allow filtering of column headers to match or extend PMPro's native export.
+	$columns = apply_filters(
+		'my_pmpro_daily_csv_header_columns',
+		array( 'id', 'username', 'firstname', 'lastname', 'email', 'registered', 'startdate', 'enddate', 'billing_amount', 'cycle_period', 'next_payment_date' )
+	);
+
+	// Write to a temp file.
+	$filename  = sanitize_file_name( 'pmpro-members-level-' . $level_id . '-' . date( 'Y-m-d' ) . '.csv' );
+	$temp_path = trailingslashit( get_temp_dir() ) . $filename;
+
+	$handle = fopen( $temp_path, 'w' );
+	if ( ! $handle ) {
+		return;
+	}
+
+	// Write header row.
+	fputcsv( $handle, $columns );
+
+	// Write one row per member.
+	foreach ( $members as $member ) {
+		$user       = get_userdata( $member->ID );
+		$first_name = get_user_meta( $member->ID, 'first_name', true );
+		$last_name  = get_user_meta( $member->ID, 'last_name', true );
+
+		// Pull subscription data via PMPro's built-in class.
+		$subscriptions   = PMPro_Subscription::get_subscriptions_for_user( $member->ID, $level_id );
+		$billing_amount  = '';
+		$cycle_period    = '';
+		$next_payment    = '';
+
+		if ( ! empty( $subscriptions ) ) {
+			$sub            = reset( $subscriptions );
+			$billing_amount = $sub->get_billing_amount();
+			$cycle_period   = $sub->get_cycle_number() . ' ' . $sub->get_cycle_period();
+			$next_payment   = $sub->get_next_payment_date( $date_format );
+		}
+
+		$row = array(
+			'id'                => $member->ID,
+			'username'          => $member->user_login,
+			'firstname'         => $first_name,
+			'lastname'          => $last_name,
+			'email'             => $member->user_email,
+			'registered'        => date( $date_format, strtotime( $member->user_registered ) ),
+			'startdate'         => date( $date_format, strtotime( $member->startdate ) ),
+			'enddate'           => ! empty( $member->enddate ) && '0000-00-00 00:00:00' !== $member->enddate
+								   ? date( $date_format, strtotime( $member->enddate ) )
+								   : '',
+			'billing_amount'    => $billing_amount,
+			'cycle_period'      => $cycle_period,
+			'next_payment_date' => $next_payment,
+		);
+
+		// Filter to match any custom column additions.
+		$row = apply_filters( 'my_pmpro_daily_csv_row', $row, $member, $level_id );
+
+		fputcsv( $handle, array_values( $row ) );
+	}
+
+	fclose( $handle );
+
+	// Send via PMPro's email class so from/fromname settings are respected.
+	$pmpro_email              = new PMProEmail();
+	$pmpro_email->email       = $email_to;
+	$pmpro_email->subject     = sprintf( 'Daily PMPro Members Export - %s (%s)', $level->name, date( 'Y-m-d' ) );
+	$pmpro_email->body        = sprintf(
+		'<p>Please find attached the daily members export for the <strong>%s</strong> membership level (%d active members).</p>',
+		esc_html( $level->name ),
+		count( $members )
+	);
+	$pmpro_email->attachments = array( $temp_path );
+	$pmpro_email->sendEmail();
+
+	// Clean up the temp file.
+	wp_delete_file( $temp_path );
+}

--- a/email/send-daily-members-list-csv-export-email.php
+++ b/email/send-daily-members-list-csv-export-email.php
@@ -134,13 +134,15 @@ function my_pmpro_generate_and_email_csv( $level_id, $email_to ) {
 	fclose( $handle );
 
 	// Send via PMPro's email class so from/fromname settings are respected.
-	$pmpro_email              = new PMProEmail();
-	$pmpro_email->email       = $email_to;
-	$pmpro_email->subject     = sprintf( 'Daily PMPro Members Export - %s (%s)', $level->name, date( 'Y-m-d' ) );
-	$pmpro_email->body        = sprintf(
-		'<p>Please find attached the daily members export for the <strong>%s</strong> membership level (%d active members).</p>',
-		esc_html( $level->name ),
-		count( $members )
+	$pmpro_email          = new PMProEmail();
+	$pmpro_email->email   = $email_to;
+	$pmpro_email->subject = sprintf( 'Daily PMPro Members Export - %s (%s)', $level->name, date( 'Y-m-d' ) );
+	$pmpro_email->data    = array(
+		'body' => sprintf(
+			'<p>Please find attached the daily members export for the <strong>%s</strong> membership level (%d active members).</p>',
+			esc_html( $level->name ),
+			count( $members )
+		),
 	);
 	$pmpro_email->attachments = array( $temp_path );
 	$pmpro_email->sendEmail();

--- a/email/send-daily-members-list-csv-export-email.php
+++ b/email/send-daily-members-list-csv-export-email.php
@@ -4,7 +4,7 @@
  *
  * Hooks into PMPro's built-in Action Scheduler (pmpro_schedule_daily) to
  * generate a CSV export per membership level and email it to the site admin.
- * 
+ *
  * title: Generate a Members CSV export for a Given Level and Email it as an Attachment.
  * layout: snippet
  * collection: email
@@ -104,10 +104,10 @@ function my_pmpro_generate_and_email_csv( $level_id, $email_to ) {
 		$last_name  = get_user_meta( $member->ID, 'last_name', true );
 
 		// Pull subscription data via PMPro's built-in class.
-		$subscriptions   = PMPro_Subscription::get_subscriptions_for_user( $member->ID, $level_id );
-		$billing_amount  = '';
-		$cycle_period    = '';
-		$next_payment    = '';
+		$subscriptions  = PMPro_Subscription::get_subscriptions_for_user( $member->ID, $level_id );
+		$billing_amount = '';
+		$cycle_period   = '';
+		$next_payment   = '';
 
 		if ( ! empty( $subscriptions ) ) {
 			$sub            = reset( $subscriptions );
@@ -125,8 +125,8 @@ function my_pmpro_generate_and_email_csv( $level_id, $email_to ) {
 			'registered'        => date( $date_format, strtotime( $member->user_registered ) ),
 			'startdate'         => date( $date_format, strtotime( $member->startdate ) ),
 			'enddate'           => ! empty( $member->enddate ) && '0000-00-00 00:00:00' !== $member->enddate
-								   ? date( $date_format, strtotime( $member->enddate ) )
-								   : '',
+									? date( $date_format, strtotime( $member->enddate ) )
+									: '',
 			'billing_amount'    => $billing_amount,
 			'cycle_period'      => $cycle_period,
 			'next_payment_date' => $next_payment,
@@ -153,7 +153,7 @@ function my_pmpro_generate_and_email_csv( $level_id, $email_to ) {
 	);
 
 	// sendEmail() resets $this->attachments, so inject the file via filter instead.
-	$attach_filter = function( $attachments ) use ( $temp_path ) {
+	$attach_filter = function ( $attachments ) use ( $temp_path ) {
 		$attachments[] = $temp_path;
 		return $attachments;
 	};

--- a/email/send-daily-members-list-csv-export-email.php
+++ b/email/send-daily-members-list-csv-export-email.php
@@ -144,8 +144,19 @@ function my_pmpro_generate_and_email_csv( $level_id, $email_to ) {
 			count( $members )
 		),
 	);
-	$pmpro_email->attachments = array( $temp_path );
+
+	// sendEmail() resets $this->attachments, so inject the file via filter instead.
+	$attach_filter = function( $attachments ) use ( $temp_path ) {
+		$attachments[] = $temp_path;
+		return $attachments;
+	};
+	add_filter( 'pmpro_email_attachments', $attach_filter );
+
+	// Send the email.
 	$pmpro_email->sendEmail();
+
+	// Remove the email attachment filter.
+	remove_filter( 'pmpro_email_attachments', $attach_filter );
 
 	// Clean up the temp file.
 	wp_delete_file( $temp_path );

--- a/email/send-daily-members-list-csv-export-email.php
+++ b/email/send-daily-members-list-csv-export-email.php
@@ -95,7 +95,7 @@ function my_pmpro_generate_and_email_csv( $level_id, $email_to ) {
 	}
 
 	// Write header row.
-	fputcsv( $handle, $columns );
+	fputcsv( $handle, $columns, ',', '"', '' );
 
 	// Write one row per member.
 	foreach ( $members as $member ) {
@@ -135,7 +135,7 @@ function my_pmpro_generate_and_email_csv( $level_id, $email_to ) {
 		// Filter to match any custom column additions.
 		$row = apply_filters( 'my_pmpro_daily_csv_row', $row, $member, $level_id );
 
-		fputcsv( $handle, array_values( $row ) );
+		fputcsv( $handle, array_values( $row ), ',', '"', '' );
 	}
 
 	fclose( $handle );

--- a/email/send-daily-members-list-csv-export-email.php
+++ b/email/send-daily-members-list-csv-export-email.php
@@ -4,10 +4,17 @@
  *
  * Hooks into PMPro's built-in Action Scheduler (pmpro_schedule_daily) to
  * generate a CSV export per membership level and email it to the site admin.
+ * 
+ * title: Generate a Members CSV export for a Given Level and Email it as an Attachment.
+ * layout: snippet
+ * collection: email
+ * category: export, action-scheduler
+ * link: TBD
  *
- * Configure the level IDs and recipient email below.
- *
- * @link https://www.paidmembershipspro.com/
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
 
 // Level IDs to export. Replace 1 and 2 with real level IDs.


### PR DESCRIPTION
Migrating snippet to library: https://gist.github.com/flintfromthebasement/fbd00ae1bde7bfab84e22f345dd997e1
https://trello.com/c/0mzRto18/

Updates:
- Fixes email body content not rendering
- Fixes attachment not being included email
- Added PMPro recipe header
- Minor WPCS
- Fixes fputcsv() deprecation warnings on PHP 8.4+ 
