### PR TITLE
Allow Pending Members to see non-member content

### DIFF
--- a/add-ons/pmpro-approvals/allow-pending-members-to-view-non-member-content.php
+++ b/add-ons/pmpro-approvals/allow-pending-members-to-view-non-member-content.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Allow pending approval members to see content shown to non-members.
+ *
+ * title: Allow Pending Approval Members to View Non-Member Content
+ * layout: snippet-example
+ * collection: content-controls
+ * category: approvals
+ * link: TBD
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * This adjusts checks for level ID 0, which PMPro uses when checking
+ * whether a user should see non-member content. If the logged-in user
+ * only has one membership level and that level is pending approval,
+ * this returns true so non-member content is shown.
+ */
+function my_pmproapprovals_show_non_member_content_to_pending_users( $has_level, $user_id, $levels ) {
+	global $pmpro_pages;
+
+	// Do not adjust checks in the WordPress admin.
+	if ( is_admin() ) {
+		return $has_level;
+	}
+
+	// Only adjust checks that are currently returning false.
+	if ( $has_level ) {
+		return $has_level;
+	}
+
+	// Let PMPro handle access checks on PMPro-generated pages.
+	if ( did_action( 'wp' ) && ! empty( $pmpro_pages ) && is_page( array_values( $pmpro_pages ) ) ) {
+		return $has_level;
+	}
+
+	// A user ID is required to check approval status.
+	if ( empty( $user_id ) ) {
+		return $has_level;
+	}
+
+	// The Approval Process for Membership Add On must be active.
+	if ( ! class_exists( 'PMPro_Approvals' ) ) {
+		return $has_level;
+	}
+
+	// Only adjust checks for non-member content.
+	$is_non_member_check = (
+		$levels === 0 ||
+		$levels === '0' ||
+		(
+			is_array( $levels ) &&
+			count( $levels ) === 1 &&
+			( in_array( 0, $levels, true ) || in_array( '0', $levels, true ) )
+		)
+	);
+
+	if ( ! $is_non_member_check ) {
+		return $has_level;
+	}
+
+	$user_levels = pmpro_getMembershipLevelsForUser( $user_id );
+
+	// Only adjust users with a single pending approval level.
+	if ( count( $user_levels ) === 1 && PMPro_Approvals::isPending( $user_id, $user_levels[0]->id ) ) {
+		return true;
+	}
+
+	return $has_level;
+}
+add_filter( 'pmpro_has_membership_level', 'my_pmproapprovals_show_non_member_content_to_pending_users', 15, 3 );

--- a/membership-levels/translate-membership-levels.php
+++ b/membership-levels/translate-membership-levels.php
@@ -89,7 +89,7 @@ function my_pmpro_levels_array( $levels ) {
 add_filter( 'pmpro_levels_array', 'my_pmpro_levels_array' );					// filter all levels
 add_filter( 'pmpro_get_membership_levels_for_user', 'my_pmpro_levels_array' );	// filter user levels
 
-// Filter checkout level
+// Filter checkout level.
 function my_pmpro_checkout_level_translate( $level ) {
 	global $pmpro_translated_levels;
 
@@ -111,3 +111,30 @@ function my_pmpro_checkout_level_translate( $level ) {
 	return $level;
 }
 add_filter( 'pmpro_checkout_level', 'my_pmpro_checkout_level_translate' );
+
+// Filter confirmation page message to use translated level name.
+// Runs at priority 5, before core's wpautop (priority 10), so str_replace matches the raw name.
+function my_pmpro_confirmation_message_translate( $message, $pmpro_invoice ) {
+	global $pmpro_translated_levels;
+
+	if ( empty( $pmpro_translated_levels ) || empty( $pmpro_invoice->membership_level ) ) {
+		return $message;
+	}
+
+	$site_locale = get_locale();
+
+	foreach ( $pmpro_translated_levels as $locale => $localized_levels ) {
+		if ( $locale !== $site_locale ) {
+			continue;
+		}
+		$level_id = $pmpro_invoice->membership_level->id;
+		if ( ! empty( $localized_levels[ $level_id ]['name'] ) ) {
+			$original_name   = $pmpro_invoice->membership_level->name;
+			$translated_name = $localized_levels[ $level_id ]['name'];
+			$message         = str_replace( $original_name, $translated_name, $message );
+		}
+	}
+
+	return $message;
+}
+add_filter( 'pmpro_confirmation_message', 'my_pmpro_confirmation_message_translate', 5, 2 );

--- a/membership-levels/translate-membership-levels.php
+++ b/membership-levels/translate-membership-levels.php
@@ -89,7 +89,7 @@ function my_pmpro_levels_array( $levels ) {
 add_filter( 'pmpro_levels_array', 'my_pmpro_levels_array' );					// filter all levels
 add_filter( 'pmpro_get_membership_levels_for_user', 'my_pmpro_levels_array' );	// filter user levels
 
-// Filter checkout level.
+// Filter checkout level
 function my_pmpro_checkout_level_translate( $level ) {
 	global $pmpro_translated_levels;
 
@@ -111,30 +111,3 @@ function my_pmpro_checkout_level_translate( $level ) {
 	return $level;
 }
 add_filter( 'pmpro_checkout_level', 'my_pmpro_checkout_level_translate' );
-
-// Filter confirmation page message to use translated level name.
-// Runs at priority 5, before core's wpautop (priority 10), so str_replace matches the raw name.
-function my_pmpro_confirmation_message_translate( $message, $pmpro_invoice ) {
-	global $pmpro_translated_levels;
-
-	if ( empty( $pmpro_translated_levels ) || empty( $pmpro_invoice->membership_level ) ) {
-		return $message;
-	}
-
-	$site_locale = get_locale();
-
-	foreach ( $pmpro_translated_levels as $locale => $localized_levels ) {
-		if ( $locale !== $site_locale ) {
-			continue;
-		}
-		$level_id = $pmpro_invoice->membership_level->id;
-		if ( ! empty( $localized_levels[ $level_id ]['name'] ) ) {
-			$original_name   = $pmpro_invoice->membership_level->name;
-			$translated_name = $localized_levels[ $level_id ]['name'];
-			$message         = str_replace( $original_name, $translated_name, $message );
-		}
-	}
-
-	return $message;
-}
-add_filter( 'pmpro_confirmation_message', 'my_pmpro_confirmation_message_translate', 5, 2 );


### PR DESCRIPTION
This is used to modify the behavior described here: https://github.com/strangerstudios/pmpro-approvals/issues/192

This recipe allow the pending member to view non-member content block or shortcode content.

The final version keeps the original behavior but adds a few safeguards and makes the membership-level check more flexible.

**Changes from the Original**

**Added an admin check earlier in the function**

The original snippet skipped admin requests after several other checks.
The final version exits immediately on admin requests, avoiding unnecessary processing.

**Made the PMPro page check safer**

The original code used `is_page( $pmpro_pages )`.
The final version only runs the page check after WordPress has finished loading the current page `(did_action( 'wp' )) `and `uses array_values( $pmpro_pages )` to ensure only page IDs are checked.
This prevents issues if the filter runs before the queried page is available.

**Added a check to confirm the Approvals Add On is active**

The final version verifies that the `PMPro_Approvals` class exists before attempting to use it.
This prevents fatal errors if the Add On is deactivated.

**Improved detection of "non-member content" checks**

The original snippet only handled cases where `$levels` was an array containing a single value of 0.
The final version also supports checks where `$levels `is passed directly as `0` or `'0'`.
This makes the snippet compatible with more ways developers may call `pmpro_hasMembershipLevel().`

**Simplified the approval check**

The original version created an instance of the Approvals class before checking the member status.
The final version calls `PMPro_Approvals::isPending() `directly, which is cleaner and easier to read.
Result

The functionality remains the same: users with a single pending approval level will see content intended for non-members.

The final version is more defensive, handles additional edge cases, and is less likely to cause issues when used alongside custom code or future PMPro updates.