### PR TITLE
Redirect non-members from bbpress forum & topic archives

### DIFF
--- a/add-ons/pmpro-bbpress/redirect-non-members-from-bbpress-forum-archive.php
+++ b/add-ons/pmpro-bbpress/redirect-non-members-from-bbpress-forum-archive.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Redirect non-members from the bbPress forums archive page.
+ * Redirect non-members from the bbPress forums and topics archive pages.
  *
- * title: Redirect Non-Members from the bbPress Forums Archive Page
+ * title: Redirect Non-Members from the bbPress Forums and Topics Archive Pages
  * layout: snippet
  * collection: bbpress
  * category: redirect, bbpress
@@ -13,17 +13,17 @@
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-function my_pmpro_bbpress_forums_archive_redirect_non_members() {
+function my_pmpro_bbpress_archives_redirect_non_members() {
 	// Let's only do this if bbPress & PMPro is active.
-	if ( ! function_exists( 'bbp_is_forum_archive' ) || ! function_exists( 'pmpro_hasMembershipLevel' ) ) {
+	if ( ! function_exists( 'bbp_is_forum_archive' ) || ! function_exists( 'bbp_is_topic_archive' ) || ! function_exists( 'pmpro_hasMembershipLevel' ) ) {
 		return;
 	}
 
-	// Let's check if we're on the bbPress forums archive page.
-	if ( bbp_is_forum_archive() && ! pmpro_hasMembershipLevel() ) {
+	// Let's check if we're on the bbPress forums or topics archive page.
+	if ( ( bbp_is_forum_archive() || bbp_is_topic_archive() ) && ! pmpro_hasMembershipLevel() ) {
 		// Redirect the user to the membership levels page.
 		wp_safe_redirect( pmpro_url( 'levels' ) );
 		exit;
 	}
 }
-add_action( 'template_redirect', 'my_pmpro_bbpress_forums_archive_redirect_non_members' );
+add_action( 'template_redirect', 'my_pmpro_bbpress_archives_redirect_non_members' );

--- a/add-ons/pmpro-bbpress/redirect-non-members-from-bbpress-forum-archive.php
+++ b/add-ons/pmpro-bbpress/redirect-non-members-from-bbpress-forum-archive.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Redirect non-members from the bbPress forums archive page.
+ *
+ * title: Redirect Non-Members from the bbPress Forums Archive Page
+ * layout: snippet
+ * collection: bbpress
+ * category: redirect, bbpress
+ * link: TBD
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function my_pmpro_bbpress_forums_archive_redirect_non_members() {
+	// Let's only do this if bbPress & PMPro is active.
+	if ( ! function_exists( 'bbp_is_forum_archive' ) || ! function_exists( 'pmpro_hasMembershipLevel' ) ) {
+		return;
+	}
+
+	// Let's check if we're on the bbPress forums archive page.
+	if ( bbp_is_forum_archive() && ! pmpro_hasMembershipLevel() ) {
+		// Redirect the user to the membership levels page.
+		wp_safe_redirect( pmpro_url( 'levels' ) );
+		exit;
+	}
+}
+add_action( 'template_redirect', 'my_pmpro_bbpress_forums_archive_redirect_non_members' );


### PR DESCRIPTION
Redirects users without a membership level away from the bbPress forums/topics archive pages to the PMPro levels page.
See: https://github.com/strangerstudios/pmpro-bbpress/issues/43