### PR TITLE
Update Tranlation to work for Confirmation page

### DIFF
--- a/membership-levels/translate-membership-levels.php
+++ b/membership-levels/translate-membership-levels.php
@@ -89,7 +89,7 @@ function my_pmpro_levels_array( $levels ) {
 add_filter( 'pmpro_levels_array', 'my_pmpro_levels_array' );					// filter all levels
 add_filter( 'pmpro_get_membership_levels_for_user', 'my_pmpro_levels_array' );	// filter user levels
 
-// Filter checkout level
+// Filter checkout level.
 function my_pmpro_checkout_level_translate( $level ) {
 	global $pmpro_translated_levels;
 
@@ -111,3 +111,30 @@ function my_pmpro_checkout_level_translate( $level ) {
 	return $level;
 }
 add_filter( 'pmpro_checkout_level', 'my_pmpro_checkout_level_translate' );
+
+// Filter confirmation page message to use translated level name.
+// Runs at priority 5, before core's wpautop (priority 10), so str_replace matches the raw name.
+function my_pmpro_confirmation_message_translate( $message, $pmpro_invoice ) {
+	global $pmpro_translated_levels;
+
+	if ( empty( $pmpro_translated_levels ) || empty( $pmpro_invoice->membership_level ) ) {
+		return $message;
+	}
+
+	$site_locale = get_locale();
+
+	foreach ( $pmpro_translated_levels as $locale => $localized_levels ) {
+		if ( $locale !== $site_locale ) {
+			continue;
+		}
+		$level_id = $pmpro_invoice->membership_level->id;
+		if ( ! empty( $localized_levels[ $level_id ]['name'] ) ) {
+			$original_name   = $pmpro_invoice->membership_level->name;
+			$translated_name = $localized_levels[ $level_id ]['name'];
+			$message         = str_replace( $original_name, $translated_name, $message );
+		}
+	}
+
+	return $message;
+}
+add_filter( 'pmpro_confirmation_message', 'my_pmpro_confirmation_message_translate', 5, 2 );


### PR DESCRIPTION
Never translated the confirmation page.

The fix: Added my_pmpro_confirmation_message_translate hooked to pmpro_confirmation_message at priority 5 (before core's wpautop at priority 10, so str_replace matches before the <p> tags get added).