### PR TITLE
Add send-invoice-email-after-membership-checkout.php

### DIFF
--- a/email/send-invoice-email-after-membership-checkout.php
+++ b/email/send-invoice-email-after-membership-checkout.php
@@ -14,7 +14,7 @@
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
 
-function pmpro_after_checkout_send_invoice_email( $user_id, $order ) {
+function my_pmpro_after_checkout_send_invoice_email( $user_id, $order ) {
 
 	$user = get_user_by( 'id', $user_id );
 
@@ -25,4 +25,4 @@ function pmpro_after_checkout_send_invoice_email( $user_id, $order ) {
 	$email = new PMProEmail();
 	$email->sendInvoiceEmail( $user, $order );
 }
-add_action( 'pmpro_after_checkout', 'pmpro_after_checkout_send_invoice_email', 10, 2 );
+add_action( 'pmpro_after_checkout', 'my_pmpro_after_checkout_send_invoice_email', 10, 2 );

--- a/email/send-invoice-email-after-membership-checkout.php
+++ b/email/send-invoice-email-after-membership-checkout.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Send the Recurring Payment Receipt (Invoice) email on initial checkout.
+ *
+ * title: Send Members an Additional Invoice via Email after Membership Checkout
+ * layout: snippet
+ * collection: email
+ * category: emails
+ * link: https://www.paidmembershipspro.com/send-members-an-additional-invoice-via-email-after-membership-checkout/
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+function pmpro_after_checkout_send_invoice_email( $user_id, $order ) {
+
+	$user = get_user_by( 'id', $user_id );
+
+	if ( ! $user ) {
+		return;
+	}
+
+	$email = new PMProEmail();
+	$email->sendInvoiceEmail( $user, $order );
+}
+add_action( 'pmpro_after_checkout', 'pmpro_after_checkout_send_invoice_email', 10, 2 );


### PR DESCRIPTION
Migrating snippet to library: https://gist.github.com/travislima/8027b0f081506c7c3d68878296358750

Updated to resolve a fatal error: `Uncaught TypeError: PMPro_Email_Template_Invoice::__construct(): Argument #1 ($user) must be of type WP_User, string given`