### PR TITLE
Add Renew Button shortcode

### DIFF
--- a/blocks-shortcodes/add-pmpro-renew-button.php
+++ b/blocks-shortcodes/add-pmpro-renew-button.php
@@ -1,32 +1,13 @@
 <?php
 /**
- * Add a [pmpro_renew_button] shortcode that displays a renew button for members
- * with an expiring membership level.
+ * Add a [pmpro_renew_button] shortcode that displays for members
+ * with one or more expiring membership levels.
  *
- * title: Insert a Renew Membership button via shortcode
+ * title: Insert a renew membership button via shortcode
  * layout: snippet
- * collection: blocks-shortcodes
+ * collection: block-shortcodes
  * category: shortcodes
  * link: https://www.paidmembershipspro.com/insert-renew-membership-button/
- *
- * Shortcode: [pmpro_renew_button]
- *
- * Shows a renew button for logged-in members whose active level has an end date.
- * Supports multiple memberships — one button per qualifying level.
- * Levels with no expiration (lifetime / open-ended recurring) output nothing.
- *
- * Attributes:
- *   expiring_soon_only - "yes" to match the Membership Account "Renew" link
- *                        (only within the expiring-soon window). Default: "no"
- *                        (any active level with an end date).
- *   button_text        - Button label. Use %s for the level name.
- *                        Default: "Renew Membership" (one level) or "Renew %s"
- *                        (multiple levels).
- *
- * Examples:
- *   [pmpro_renew_button]
- *   [pmpro_renew_button expiring_soon_only="yes"]
- *   [pmpro_renew_button button_text="Renew Your %s Plan"]
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
@@ -37,16 +18,23 @@
 /**
  * Shortcode callback: [pmpro_renew_button]
  *
+ * Attributes:
+ *   expiring_soon_only - "yes" to match the Membership Account "Renew" link
+ *                        (only within the expiring-soon window). Default: "no".
+ *   button_text        - Button label. Use !!name!! for the level name.
+ *                        Default: "Renew Membership" (one level) or
+ *                        "Renew !!name!!" (multiple levels).
+ *
  * @param array|string $atts Shortcode attributes.
  * @return string HTML for one or more renew buttons, or empty string.
  */
 function my_pmpro_renew_button_shortcode( $atts ) {
-	// Bail if PMPro is not active.
-	if ( ! function_exists( 'pmpro_getMembershipLevelsForUser' ) || ! function_exists( 'pmpro_url' ) ) {
+
+	// Bail if PMPro isn't active.
+	if ( ! function_exists( 'pmpro_getMembershipLevelsForUser' ) ) {
 		return '';
 	}
 
-	// Must be logged in.
 	if ( ! is_user_logged_in() ) {
 		return '';
 	}
@@ -60,20 +48,17 @@ function my_pmpro_renew_button_shortcode( $atts ) {
 		'pmpro_renew_button'
 	);
 
-	$expiring_soon_only = ( 'yes' === strtolower( $atts['expiring_soon_only'] ) );
-	$user_id            = get_current_user_id();
-
 	// Active levels only (expired members no longer hold the level).
-	$levels = pmpro_getMembershipLevelsForUser( $user_id );
-
+	$levels = pmpro_getMembershipLevelsForUser( get_current_user_id() );
 	if ( empty( $levels ) || ! is_array( $levels ) ) {
 		return '';
 	}
 
-	$use_level_name = ( count( $levels ) > 1 );
-	$buttons        = array();
+	$expiring_soon_only = ( 'yes' === strtolower( $atts['expiring_soon_only'] ) );
+	$renewable          = array();
 
 	foreach ( $levels as $level ) {
+
 		// Skip levels with no end date (lifetime / no fixed expiration).
 		if ( empty( $level->enddate ) ) {
 			continue;
@@ -84,42 +69,38 @@ function my_pmpro_renew_button_shortcode( $atts ) {
 			continue;
 		}
 
-		// Modern checkout query arg (core uses pmpro_level=).
-		$checkout_url = pmpro_url( 'checkout', '?pmpro_level=' . (int) $level->id, 'https' );
-
-		if ( empty( $checkout_url ) ) {
-			continue;
-		}
-
-		// Button label.
-		if ( ! empty( $atts['button_text'] ) ) {
-			$label = sprintf( $atts['button_text'], $level->name );
-		} elseif ( $use_level_name ) {
-			/* translators: %s: membership level name */
-			$label = sprintf( __( 'Renew %s', 'pmpro-snippets-library' ), $level->name );
-		} else {
-			$label = __( 'Renew Membership', 'pmpro-snippets-library' );
-		}
-
-		$buttons[] = sprintf(
-			'<a class="%1$s" href="%2$s" aria-label="%3$s">%4$s</a>',
-			esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-renew pmpro_btn-select pmpro-renew-button', 'pmpro-renew-button' ) ),
-			esc_url( $checkout_url ),
-			esc_attr(
-				sprintf(
-					/* translators: %s: membership level name */
-					__( 'Renew your %s membership', 'pmpro-snippets-library' ),
-					$level->name
-				)
-			),
-			esc_html( $label )
-		);
+		$renewable[] = $level;
 	}
 
-	if ( empty( $buttons ) ) {
+	if ( empty( $renewable ) ) {
 		return '';
 	}
 
-	return implode( "\n", $buttons );
+	// Name the level only when more than one button is actually rendered.
+	$use_level_name = ( count( $renewable ) > 1 );
+	$buttons        = array();
+
+	foreach ( $renewable as $level ) {
+
+		if ( ! empty( $atts['button_text'] ) ) {
+			$text = $atts['button_text'];
+		} elseif ( $use_level_name ) {
+			/* translators: !!name!! is replaced with the membership level name. */
+			$text = __( 'Renew !!name!!', 'pmpro-snippets-library' );
+		} else {
+			$text = __( 'Renew Membership', 'pmpro-snippets-library' );
+		}
+
+		// Core builds and escapes the checkout URL, class attribute, and label,
+		// and swaps !!name!! and the other level tokens into the label.
+		$buttons[] = pmpro_getCheckoutButton(
+			(int) $level->id,
+			$text,
+			'pmpro_btn pmpro_btn-select pmpro-renew-button'
+		);
+	}
+
+	// Button styles are scoped to .pmpro in the core frontend CSS.
+	return '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro' ) ) . '">' . implode( "\n", $buttons ) . '</div>';
 }
 add_shortcode( 'pmpro_renew_button', 'my_pmpro_renew_button_shortcode' );

--- a/blocks-shortcodes/add-pmpro-renew-button.php
+++ b/blocks-shortcodes/add-pmpro-renew-button.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Add a [pmpro_renew_button] shortcode that displays a renew button for members
+ * with an expiring membership level.
+ *
+ * title: Insert a Renew Membership button via shortcode
+ * layout: snippet
+ * collection: blocks-shortcodes
+ * category: shortcodes
+ * link: https://www.paidmembershipspro.com/insert-renew-membership-button/
+ *
+ * Shortcode: [pmpro_renew_button]
+ *
+ * Shows a renew button for logged-in members whose active level has an end date.
+ * Supports multiple memberships — one button per qualifying level.
+ * Levels with no expiration (lifetime / open-ended recurring) output nothing.
+ *
+ * Attributes:
+ *   expiring_soon_only - "yes" to match the Membership Account "Renew" link
+ *                        (only within the expiring-soon window). Default: "no"
+ *                        (any active level with an end date).
+ *   button_text        - Button label. Use %s for the level name.
+ *                        Default: "Renew Membership" (one level) or "Renew %s"
+ *                        (multiple levels).
+ *
+ * Examples:
+ *   [pmpro_renew_button]
+ *   [pmpro_renew_button expiring_soon_only="yes"]
+ *   [pmpro_renew_button button_text="Renew Your %s Plan"]
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * Shortcode callback: [pmpro_renew_button]
+ *
+ * @param array|string $atts Shortcode attributes.
+ * @return string HTML for one or more renew buttons, or empty string.
+ */
+function my_pmpro_renew_button_shortcode( $atts ) {
+	// Bail if PMPro is not active.
+	if ( ! function_exists( 'pmpro_getMembershipLevelsForUser' ) || ! function_exists( 'pmpro_url' ) ) {
+		return '';
+	}
+
+	// Must be logged in.
+	if ( ! is_user_logged_in() ) {
+		return '';
+	}
+
+	$atts = shortcode_atts(
+		array(
+			'expiring_soon_only' => 'no',
+			'button_text'        => '',
+		),
+		$atts,
+		'pmpro_renew_button'
+	);
+
+	$expiring_soon_only = ( 'yes' === strtolower( $atts['expiring_soon_only'] ) );
+	$user_id            = get_current_user_id();
+
+	// Active levels only (expired members no longer hold the level).
+	$levels = pmpro_getMembershipLevelsForUser( $user_id );
+
+	if ( empty( $levels ) || ! is_array( $levels ) ) {
+		return '';
+	}
+
+	$use_level_name = ( count( $levels ) > 1 );
+	$buttons        = array();
+
+	foreach ( $levels as $level ) {
+		// Skip levels with no end date (lifetime / no fixed expiration).
+		if ( empty( $level->enddate ) ) {
+			continue;
+		}
+
+		// Optional: only show inside the same window as the Account page Renew link.
+		if ( $expiring_soon_only && ! pmpro_isLevelExpiringSoon( $level ) ) {
+			continue;
+		}
+
+		// Modern checkout query arg (core uses pmpro_level=).
+		$checkout_url = pmpro_url( 'checkout', '?pmpro_level=' . (int) $level->id, 'https' );
+
+		if ( empty( $checkout_url ) ) {
+			continue;
+		}
+
+		// Button label.
+		if ( ! empty( $atts['button_text'] ) ) {
+			$label = sprintf( $atts['button_text'], $level->name );
+		} elseif ( $use_level_name ) {
+			/* translators: %s: membership level name */
+			$label = sprintf( __( 'Renew %s', 'pmpro-snippets-library' ), $level->name );
+		} else {
+			$label = __( 'Renew Membership', 'pmpro-snippets-library' );
+		}
+
+		$buttons[] = sprintf(
+			'<a class="%1$s" href="%2$s" aria-label="%3$s">%4$s</a>',
+			esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-renew pmpro_btn-select pmpro-renew-button', 'pmpro-renew-button' ) ),
+			esc_url( $checkout_url ),
+			esc_attr(
+				sprintf(
+					/* translators: %s: membership level name */
+					__( 'Renew your %s membership', 'pmpro-snippets-library' ),
+					$level->name
+				)
+			),
+			esc_html( $label )
+		);
+	}
+
+	if ( empty( $buttons ) ) {
+		return '';
+	}
+
+	return implode( "\n", $buttons );
+}
+add_shortcode( 'pmpro_renew_button', 'my_pmpro_renew_button_shortcode' );


### PR DESCRIPTION
From https://gist.github.com/travislima/caf4e40b75b913372e19692cff1b3644#file-pmpro-renew-membership-shortcode-php

A few ways to use this shortcode:

`[pmpro_renew_button]` - shows all active levels with an expiration date in a row of buttons with the text "Renew {Level Name]" if more than one or just "Renew Membership" if only one found

`[pmpro_renew_button button_text="Renew !!name!! soon or you lose!"]` - shows all active levels with an expiration date in a row of buttons with the text "Renew {Level Name] soon or you lose!"

`[pmpro_renew_button expiring_soon_only="yes"]` - shows all expiring soon (pmpro_isLevelExpiringSoon) active levels with an expiration date in a row of buttons with the text "Renew {Level Name]" if more than one or just "Renew Membership" if only one found.
