### PR TITLE
Add snippet to display restricted PDFs inline in the browser

### DIFF
--- a/restricting-content/display-restricted-pdfs-inline-in-browser.php
+++ b/restricting-content/display-restricted-pdfs-inline-in-browser.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Display restricted PDFs inline in the browser instead of forcing a download.
+ *
+ * By default, Paid Memberships Pro serves restricted images inline and all other
+ * file types as downloads. This recipe also serves PDFs inline.
+ *
+ * Restrict files: https://www.paidmembershipspro.com/locking-down-protecting-files-with-pmpro/
+ *
+ * title: Display Restricted PDFs in the Browser
+ * layout: snippet
+ * collection: restricting-content
+ * category: content, restriction
+ * link: TBD
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+function my_pmpro_inline_restricted_pdfs( $content_disposition, $file, $file_dir, $file_path ) {
+	$finfo     = finfo_open( FILEINFO_MIME_TYPE );
+	$mime_type = finfo_file( $finfo, $file_path );
+	finfo_close( $finfo );
+
+	if ( 'application/pdf' === $mime_type ) {
+		return 'inline';
+	}
+
+	return $content_disposition;
+}
+add_filter( 'pmpro_restricted_file_content_disposition', 'my_pmpro_inline_restricted_pdfs', 10, 4 );

--- a/restricting-content/display-restricted-pdfs-inline-in-browser.php
+++ b/restricting-content/display-restricted-pdfs-inline-in-browser.php
@@ -2,10 +2,7 @@
 /**
  * Display restricted PDFs inline in the browser instead of forcing a download.
  *
- * By default, Paid Memberships Pro serves restricted images inline and all other
- * file types as downloads. This recipe also serves PDFs inline.
- *
- * Restrict files: https://www.paidmembershipspro.com/locking-down-protecting-files-with-pmpro/
+ * For more information about restricting files with PMPro visit: https://www.paidmembershipspro.com/locking-down-protecting-files-with-pmpro/
  *
  * title: Display Restricted PDFs in the Browser
  * layout: snippet
@@ -19,11 +16,9 @@
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
 function my_pmpro_inline_restricted_pdfs( $content_disposition, $file, $file_dir, $file_path ) {
-	$finfo     = finfo_open( FILEINFO_MIME_TYPE );
-	$mime_type = finfo_file( $finfo, $file_path );
-	finfo_close( $finfo );
+	$filetype = wp_check_filetype( $file_path );
 
-	if ( 'application/pdf' === $mime_type ) {
+	if ( 'application/pdf' === $filetype['type'] ) {
 		return 'inline';
 	}
 


### PR DESCRIPTION
Adds `restricting-content/display-restricted-pdfs-inline-in-browser.php`.

PMPro serves restricted images inline and all other file types as downloads. This snippet filters `pmpro_restricted_file_content_disposition` (added in PMPro 3.6) to also serve PDFs inline, so members can read them in the browser instead of being forced to download.

The MIME type is read with `finfo` so only real PDFs are affected; anything else falls through to the disposition core already chose.

`link:` is set to `TBD` — there's no companion article for this recipe yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)