### PR TITLE
Update

### DIFF
--- a/add-ons/pmpro-set-expiration-dates/change-year-by-month.php
+++ b/add-ons/pmpro-set-expiration-dates/change-year-by-month.php
@@ -8,16 +8,19 @@
  * collection: add-ons, pmpro-set-expiration-dates
  * category: expiration date
  * link: https://www.paidmembershipspro.com/adjust-set-expiration-year-after-specific-month/
- * 
- * Automatically adjust Y1-xx-xx to be Y2-xx-xx if the current month is set.
- * Change line 35 for the month to change to next year.
+ *
+ * The Set Expiration Date add-on stores its raw expiration string using year
+ * placeholders: "Y1" (or the shorthand "Y") is the current year and "Y2" is the
+ * next year. Once the site's current month reaches the cutoff month set in
+ * $cutoff_month, this recipe rewrites the current-year placeholder to the
+ * next-year placeholder so new signups expire the following year instead of
+ * the current one. Change $cutoff_month to set the month that rolls forward.
  *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
  * Read this companion article for step-by-step directions on either method.
  * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
  */
-
 function my_pmpro_adjust_expiration_year_after_month( $raw_date ) {
 
 	// No Set Expiration Date configured, nothing to adjust.
@@ -25,10 +28,11 @@ function my_pmpro_adjust_expiration_year_after_month( $raw_date ) {
 		return $raw_date;
 	}
 
-	// Change this to the month (1-12) after which new signups should roll to next year.
+	// First month (1-12) that rolls new signups forward to next year. Inclusive:
+	// this month and every month after it roll forward.
 	$cutoff_month = 10; // October.
 
-	$current_month = (int) gmdate( 'n' );
+	$current_month = (int) current_time( 'n' );
 
 	if ( $current_month >= $cutoff_month ) {
 		// Handle both the shorthand "Y" and the explicit "Y1" current-year placeholder.


### PR DESCRIPTION
What changed:

- current_time( 'n' ) replaces gmdate( 'n' ), so the cutoff follows the site's timezone rather than UTC. 
- New docblock describing the placeholder scheme and the cutoff behavior in plain terms. (The stray/incorrect line from the old docblock is gone — nothing carried over, so nothing to drop.) 
- $cutoff_month comment now frames it as the inclusive first month that rolls forward, matching the >= check, rather than "after."