### PR TITLE
Add snippet to customize cancellation email for failed payments

### DIFF
--- a/email/customize-cancellation-email-for-failed-payments.php
+++ b/email/customize-cancellation-email-for-failed-payments.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Add a {{ cancelled_due_to_payment_failure }} email template variable to the
+ * PMPro Cancel emails so you can vary the wording with Liquid syntax when a
+ * membership was cancelled because a recurring payment failed.
+ *
+ * Usage in Memberships > Settings > Email Templates > Cancel:
+ *
+ *   {% if cancelled_due_to_payment_failure %}
+ *   Content for members cancelled due to payment failure.
+ *   {% else %}
+ *   Content for members who initiated cancellation.
+ *   {% endif %}
+ *
+ * title: Customize the Cancellation Email for Memberships Cancelled Due to Failed Payments
+ * layout: snippet
+ * collection: email
+ * category: emails, email templates
+ * link: TBD
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion article for step-by-step directions on either method.
+ * https://www.paidmembershipspro.com/create-a-plugin-for-pmpro-customizations/
+ */
+
+/**
+ * Was this membership cancelled by the gateway after a payment failed?
+ *
+ * @param int $user_id  The ID of the member.
+ * @param int $level_id The cancelled membership level ID.
+ * @return bool Whether the cancellation was caused by a failed payment.
+ */
+function my_pmpro_cancelled_due_to_payment_failure( $user_id, $level_id ) {
+	if ( ! class_exists( 'PMPro_Subscription' ) ) {
+		return false;
+	}
+
+	// Bail if the cancellation was admin/member initiated.
+	if ( is_user_logged_in() ) {
+		return false;
+	}
+
+	// Get the most recent subscription for the cancelled level.
+	$subscriptions = PMPro_Subscription::get_subscriptions_for_user(
+		$user_id,
+		$level_id,
+		array( 'active', 'cancelled' )
+	);
+	if ( empty( $subscriptions ) ) {
+		return false;
+	}
+	$subscription = current( $subscriptions );
+
+	// A failed payment leaves a pending order. Cancelling then flips it to error
+	// in PMPro_Subscription::save(), before the cancel email, so accept both.
+	$failed_orders = $subscription->get_orders( array( 'status' => array( 'pending', 'error' ) ) );
+
+	foreach ( $failed_orders as $order ) {
+		// Only the failure handler writes this meta.
+		if ( get_pmpro_membership_order_meta( $order->id, 'last_failure_email_sent', true ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Add a {{ cancelled_due_to_payment_failure }} variable to the cancel emails.
+ *
+ * @param array      $data  The email template variables.
+ * @param PMProEmail $email The email object being sent.
+ * @return array The filtered email template variables.
+ */
+function my_pmpro_add_payment_failure_email_variable( $data, $email ) {
+	// Only affect the cancel emails. Remove 'cancel_admin' if you only want to change the email sent to the member.
+	if ( empty( $email->template ) || ! in_array( $email->template, array( 'cancel', 'cancel_admin' ), true ) ) {
+		return $data;
+	}
+
+	// Default to empty so the variable always exists and never falls through to usermeta lookup.
+	$data['cancelled_due_to_payment_failure'] = '';
+
+	// Bail if there is no membership level to check.
+	if ( empty( $data['membership_id'] ) ) {
+		return $data;
+	}
+
+	// Resolve the user from the email data, not the recipient address.
+	if ( empty( $data['user_login'] ) ) {
+		return $data;
+	}
+	$user = get_user_by( 'login', $data['user_login'] );
+	if ( empty( $user ) ) {
+		return $data;
+	}
+
+	if ( my_pmpro_cancelled_due_to_payment_failure( $user->ID, (int) $data['membership_id'] ) ) {
+		$data['cancelled_due_to_payment_failure'] = '1';
+	}
+
+	return $data;
+}
+add_filter( 'pmpro_email_data', 'my_pmpro_add_payment_failure_email_variable', 10, 2 );

--- a/email/customize-cancellation-email-for-failed-payments.php
+++ b/email/customize-cancellation-email-for-failed-payments.php
@@ -3,6 +3,7 @@
  * Add a {{ cancelled_due_to_payment_failure }} email template variable to the
  * PMPro Cancel emails so you can vary the wording with Liquid syntax when a
  * membership was cancelled because a recurring payment failed.
+ * Requires Paid Memberships Pro v3.7+ for Liquid syntax in email templates.
  *
  * Usage in Memberships > Settings > Email Templates > Cancel:
  *
@@ -11,6 +12,10 @@
  *   {% else %}
  *   Content for members who initiated cancellation.
  *   {% endif %}
+ *
+ * Gateway support: needs a gateway that uses PMPro's built-in handling for
+ * failed recurring payments, such as Stripe and PayPal. Members on gateways
+ * that handle failed payments their own way always get the {% else %} content.
  *
  * title: Customize the Cancellation Email for Memberships Cancelled Due to Failed Payments
  * layout: snippet
@@ -58,6 +63,7 @@ function my_pmpro_cancelled_due_to_payment_failure( $user_id, $level_id ) {
 
 	foreach ( $failed_orders as $order ) {
 		// Only the failure handler writes this meta.
+		// A retry reuses the order, so one still incomplete is assumed unresolved.
 		if ( get_pmpro_membership_order_meta( $order->id, 'last_failure_email_sent', true ) ) {
 			return true;
 		}


### PR DESCRIPTION
Adds a `{{ cancelled_due_to_payment_failure }}` email template variable to the Cancel and Cancel Admin emails, so the body can use Liquid syntax to show different content when a membership was cancelled because a recurring payment failed:

```
{% if cancelled_due_to_payment_failure %}
Content for members cancelled due to payment failure.
{% else %}
Content for members who initiated cancellation.
{% endif %}
```

### How it detects the cause

Core does not pass a cancellation reason to the cancel email, but every gateway routes recurring payment failures through `pmpro_handle_recurring_payment_failure_at_gateway()`, which saves a pending order and adds `last_failure_email_sent` order meta to it. A later successful retry reuses that same order and flips it to success, so an unresolved failure is simply an incomplete order carrying that meta.

Two details this depends on:

- `PMPro_Subscription::save()` marks incomplete orders as error when the subscription is cancelled, and that runs before the cancel email is sent, so both `pending` and `error` count.
- `get_subscriptions_for_user()` defaults to active subscriptions only, and the subscription is already cancelled by email time, so the status list is passed explicitly.

Cancellations requested by a member or an admin are excluded with an `is_user_logged_in()` check, since gateway webhooks are unauthenticated. Without it, a member who cancels while payments are still retrying would be told their membership ended because of a payment failure.

### Still to do

- `link:` in the header is `TBD` pending the article URL.

### Testing

Verified on Stripe: a subscription cancelled after retries were exhausted takes the payment-failure branch, and a member-initiated cancellation takes the else branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
